### PR TITLE
docs: add documentation for how to use pre-commit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,11 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-      - run: uv pip install pre-commit
+
+      - name: Create venv and install pre-commit
+        run: |
+          uv venv
+          uv pip install pre-commit
 
       - name: Cache pre-commit hooks
         uses: actions/cache@v3
@@ -45,7 +49,7 @@ jobs:
           fi
 
   tests:
-    needs: code-quality  # Make tests run after code quality checks pass
+    needs: code-quality
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: CI
 on:
   push:
     branches: [main]
@@ -9,7 +9,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests-base:
+  code-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv pip install pre-commit
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
+
+      - name: Check if changes were made
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::Code formatting issues found. Run pre-commit locally and commit changes."
+            git diff
+            exit 1
+          fi
+
+  tests:
+    needs: code-quality  # Make tests run after code quality checks pass
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -36,6 +72,7 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync
+
       - name: Run tests with pytest
         run: uv run pytest --cov=corral
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Create venv and install pre-commit
         run: |
           uv venv
+          source .venv/bin/activate
           uv pip install pre-commit
 
       - name: Cache pre-commit hooks
@@ -38,7 +39,9 @@ jobs:
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run pre-commit checks
-        run: pre-commit run --all-files
+        run: |
+          source .venv/bin/activate
+          pre-commit run --all-files
 
       - name: Check if changes were made
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v0.5.0
     hooks:
       - id: ruff
-        args: [--fix, --unsafe-fixes]
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -117,3 +117,18 @@ runner = MatAgentBenchmark(interface, agent)
 result = runner.bench()
 ```
 
+## Development 
+
+This project uses pre-commit hooks to maintain code quality. The hooks run automatically on each commit to ensure consistent code formatting and catch common issues early.
+
+### Setup
+
+1. Install Python dependencies: `pip install pre-commit`
+2. Install the pre-commit hooks: `pre-commit install`
+
+The checks will run automatically when you commit changes. However, you can also run them manually:
+
+- Run on all files: `pre-commit run --all-files`
+- Run on specific files: `pre-commit run --files path/to/file1.py path/to/file2.py`
+
+For best experience, install `ruff` in your editor to format code on save and to show linting errors.


### PR DESCRIPTION
Once we have few open PRs, we should format everything. 

The official CI requires a paid plan, but we can add a pre-commit step in the testing CI.

## Summary by Sourcery

Documentation:
- Document how to set up and use pre-commit hooks for code quality and consistency.