### PR TITLE
chore: improve parsing type annotation for tools

### DIFF
--- a/src/corral/utils.py
+++ b/src/corral/utils.py
@@ -18,10 +18,7 @@ def format_type_annotation(annotation):
 
     # Handle basic types
     if isinstance(annotation, type):
-        if annotation is type(None):
-            return "None"
-        return annotation.__name__
-
+        return "None" if annotation is type(None) else annotation.__name__
     # Handle new-style union (str | int)
     if isinstance(annotation, type | type(None)):
         return annotation.__name__

--- a/src/corral/utils.py
+++ b/src/corral/utils.py
@@ -3,7 +3,7 @@ import json
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import get_type_hints
+from typing import Optional, Union, get_args, get_origin, get_type_hints
 
 from modal import App, Image, Mount, Secret, Volume
 
@@ -13,8 +13,59 @@ from corral.base import ModalTool, Tool, ToolArgument
 MODAL_TOOL_REGISTRY = {}
 
 
+def format_type_annotation(annotation):
+    """Formats type annotations to readable strings."""
+
+    # Handle basic types
+    if isinstance(annotation, type):
+        if annotation is type(None):
+            return "None"
+        return annotation.__name__
+
+    # Handle new-style union (str | int)
+    if isinstance(annotation, type | type(None)):
+        return annotation.__name__
+
+    # Handle new-style unions using '|'
+    if get_origin(annotation) is Union:
+        args = [format_type_annotation(arg) for arg in get_args(annotation)]
+        return " | ".join(args).replace("NoneType", "None")
+
+    # Handle old-style unions (Union[str, int])
+    if hasattr(annotation, "__origin__") and annotation.__origin__ is Union:
+        args = [format_type_annotation(arg) for arg in annotation.__args__]
+        return " | ".join(args).replace("NoneType", "None")
+
+    # Handle Optional (which is Union[T, None])
+    if annotation is Optional:
+        return f"{format_type_annotation(annotation.__args__[0])} | None"
+
+    # Handle generic types like list, dict, etc.
+    if hasattr(annotation, "__origin__"):
+        origin = format_type_annotation(annotation.__origin__)
+        args = ", ".join(format_type_annotation(arg) for arg in annotation.__args__)
+        return f"{origin}[{args}]"
+
+    # Fallback to string representation for unknown types
+    return str(annotation)
+
+
 def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
-    """Parse function docstring to get description and arguments"""
+    """Parse function docstring to get description and arguments.
+
+    This function extracts the description and arguments from a function's docstring.
+    It expects a docstring with a description section and an Args section.
+
+    Args:
+        func: The function to parse docstring from
+
+    Returns:
+        tuple: (description, arguments) where description is a string and
+               arguments is a list of ToolArgument objects
+
+    Raises:
+        ValueError: If the docstring is missing or doesn't have an Args section
+    """
     doc = inspect.getdoc(func)
     if not doc:
         raise ValueError(f"Function {func.__name__} must have a docstring")
@@ -67,7 +118,8 @@ def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
         if arg_name not in type_hints:
             continue  # Skip non-argument sections like Returns
 
-        arg_type = type_hints[arg_name].__name__
+        arg_annotation = type_hints[arg_name]
+        arg_type = format_type_annotation(arg_annotation)
 
         # Check if argument has default value
         signature = inspect.signature(func)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,7 +1,9 @@
+from typing import Optional, Union
+
 import pytest
 
 from corral.base import Tool
-from corral.utils import tool
+from corral.utils import format_type_annotation, tool
 
 
 # Sample functions for testing
@@ -39,13 +41,13 @@ def sample_tool_with_defaults(x: float, y: float = 1.0) -> float:
 
 
 # Fixtures
-@pytest.fixture
+@pytest.fixture()
 def calculator_tool():
     """Fixture providing a basic calculator tool"""
     return tool(sample_valid_tool)
 
 
-@pytest.fixture
+@pytest.fixture()
 def calculator_with_defaults():
     """Fixture providing a calculator with default arguments"""
     return tool(sample_tool_with_defaults)
@@ -69,7 +71,7 @@ class TestToolCreation:
         assert operation_arg.choices == ["add", "subtract", "multiply", "divide"]
 
     @pytest.mark.parametrize(
-        "operation,x,y,expected",
+        ("operation", "x", "y", "expected"),
         [
             ("add", 5, 3, "8"),
             ("subtract", 5, 3, "2"),
@@ -99,7 +101,7 @@ class TestToolCreation:
 
 class TestArgumentValidation:
     @pytest.mark.parametrize(
-        "args,expected_valid,error_message",
+        ("args", "expected_valid", "error_message"),
         [
             ({"x": 1.0}, False, "Missing required argument"),
             (
@@ -193,3 +195,101 @@ class TestDocstringValidation:
         with pytest.raises(ValueError) as exc_info:
             tool(test_func)
         assert "Missing documentation for parameters" in str(exc_info.value)
+
+
+def test_format_type_annotation():
+    """Test the format_type_annotation function with various types including unions."""
+    # Basic types
+    assert format_type_annotation(str) == "str"
+    assert format_type_annotation(int) == "int"
+    assert format_type_annotation(float) == "float"
+
+    # Union types using | operator
+    union_type = str | int
+    assert format_type_annotation(union_type) == "str | int"
+
+    # Union types using typing.Union
+
+    union_type_old = Union[str, int]  # noqa: UP007
+    assert format_type_annotation(union_type_old) == "str | int"
+
+    # Optional type (which is Union[T, None])
+    optional_type = Optional[str]  # noqa: UP007
+    assert format_type_annotation(optional_type) == "str | None"
+
+    # Nested unions and complex types
+    complex_union = list[str | int] | None
+    formatted = format_type_annotation(complex_union)
+    assert "list" in formatted
+    assert "str | int" in formatted
+    assert "None" in formatted
+
+    # Tuple with mixed types
+    assert format_type_annotation(tuple[str, int]) == "tuple[str, int]"
+
+
+def test_integration_with_actual_docstring():
+    """Test with a docstring similar to the original function.
+
+    This test verifies that a function with union types like `list[float] | None`
+    is properly parsed and the tool is correctly created with appropriate
+    type information.
+    """
+
+    @tool
+    def test_function(
+        slab_cif: str,
+        adsorbate_cif: str,
+        height: float = 2.0,
+        site: list[float] | None = None,
+    ) -> str:
+        """
+        Place an adsorbate on a slab at a specified adsorption site.
+        If no site is specified, choose one from the top sites automatically.
+
+        Args:
+            slab_cif: CIF string of the slab.
+            adsorbate_cif: CIF string of the adsorbate.
+            height: Height (Å) above the slab surface where the adsorbate should be placed.
+            site: Optional fractional coordinate [x, y, z] for placement.
+                If None, the first top site will be used.
+        Returns:
+            str: CIF string of the combined structure.
+        """
+        return "Test result"
+
+    # Verify all arguments were correctly parsed
+    args = {arg.name: arg for arg in test_function.arguments}
+
+    assert len(args) == 4
+    assert "slab_cif" in args
+    assert "adsorbate_cif" in args
+    assert "height" in args
+    assert "site" in args
+
+    # Check specific properties of the site parameter
+    site_param = args["site"]
+
+    # Allow for different valid representations of the type
+    valid_type_patterns = [
+        "list[float] | None",
+        "list[float] | NoneType",
+        "list | None",
+        "list | NoneType",
+    ]
+
+    assert any(site_param.type == pattern for pattern in valid_type_patterns) or (
+        "list" in site_param.type.lower()
+        and ("none" in site_param.type.lower() or "nonetype" in site_param.type.lower())
+    ), f"Type '{site_param.type}' doesn't match any expected pattern"
+
+    assert site_param.default is None
+
+    # Verify the docstring description was properly captured
+    assert "place an adsorbate on a slab" in test_function.description.lower()
+
+    # Test that the tool can be executed
+    result = test_function.execute(
+        slab_cif="sample_slab", adsorbate_cif="sample_adsorbate", height=2.5
+    )
+    assert result == "Test result"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -269,21 +269,12 @@ def test_integration_with_actual_docstring():
 
     # Check specific properties of the site parameter
     site_param = args["site"]
+    expected_type = format_type_annotation(list[float] | None)
 
-    # Allow for different valid representations of the type
-    valid_type_patterns = [
-        "list[float] | None",
-        "list[float] | NoneType",
-        "list | None",
-        "list | NoneType",
-    ]
-
-    assert any(site_param.type == pattern for pattern in valid_type_patterns) or (
-        "list" in site_param.type.lower()
-        and ("none" in site_param.type.lower() or "nonetype" in site_param.type.lower())
-    ), f"Type '{site_param.type}' doesn't match any expected pattern"
-
-    assert site_param.default is None
+    # Then make the assertion strict
+    assert (
+        site_param.type == expected_type
+    ), f"Expected type '{expected_type}', got '{site_param.type}'"
 
     # Verify the docstring description was properly captured
     assert "place an adsorbate on a slab" in test_function.description.lower()


### PR DESCRIPTION
fixes #45

## Summary by Sourcery

Improve type annotation parsing and formatting for tools, adding support for complex type annotations like unions and optional types

Bug Fixes:
- Fix type annotation parsing to correctly handle modern Python type hints like union types and optional types

Enhancements:
- Implement a robust type annotation formatting function that handles various type annotation scenarios including unions, optional types, and generic types

Tests:
- Add comprehensive test cases for type annotation formatting
- Create integration tests for parsing complex type annotations in tool creation

Chores:
- Update pytest fixtures to use parentheses
- Improve parameter type hints in test cases