### PR TITLE
fix: solve final answer parsing

### DIFF
--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -1,5 +1,6 @@
 import importlib.resources
 import json
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -140,12 +141,15 @@ class ToolCallingAgent:
                     **self.kwargs,
                 )
 
-                final_answer_match = re.search(r"Final Answer: (.*)", llm_response)
-
                 content = llm_response.content
                 if content:
-                    if final_answer_match in content:
-                        messages.append(LiteLLMMessage(role="assistant", content=content))
+                    final_answer_match = re.search(
+                        r"Final Answer:\s*(.*)", content, re.IGNORECASE
+                    )
+                    if final_answer_match:
+                        messages.append(
+                            LiteLLMMessage(role="assistant", content=content)
+                        )
                         return final_answer_match.group(1).strip(), messages
 
                 tool_calls = llm_response.tool_calls


### PR DESCRIPTION
## Summary by Sourcery

Fix final answer parsing by performing regex search on the response content with case-insensitive whitespace handling and correctly checking for match existence before returning.

Bug Fixes:
- Search for "Final Answer" within the LLM response content using a case-insensitive regex that handles optional whitespace.
- Fix the conditional to properly detect a regex match object instead of comparing it to the content.