### PR TITLE
fix: correct scoring in the spectra tasks

### DIFF
--- a/tasks/spectra_elu_easy/spectra_elu_easy/score.py
+++ b/tasks/spectra_elu_easy/spectra_elu_easy/score.py
@@ -1,7 +1,5 @@
 import modal
-from rdkit import Chem, DataStructs
-from rdkit.Chem import rdMolDescriptors
-from rdkit.Chem.Scaffolds import MurckoScaffold
+from rdkit import Chem
 
 get_isomeric_smiles = modal.Function.from_name("chemenv", "get_isomeric_smiles_pubchem")
 
@@ -17,12 +15,8 @@ def score_molecule_similarity(prediction: str, ground_truth: str) -> float:
     Returns:
         float: Score between 0.0 and 1.0 based on similarity
     """
-    # Convert possible names into SMILES
-    try:
-        prediction = get_isomeric_smiles.remote(prediction)
-    except Exception:
-        return 0.0
-
+    if prediction == ground_truth:
+        return 1.0
     try:
         pred_mol = Chem.MolFromSmiles(prediction)
     except Exception:
@@ -41,27 +35,4 @@ def score_molecule_similarity(prediction: str, ground_truth: str) -> float:
     if Chem.MolToSmiles(pred_mol) == Chem.MolToSmiles(true_mol):
         return 1.0
 
-    # Check scaffold match
-    pred_scaffold = MurckoScaffold.GetScaffoldForMol(pred_mol)
-    true_scaffold = MurckoScaffold.GetScaffoldForMol(true_mol)
-    if Chem.MolToSmiles(pred_scaffold) == Chem.MolToSmiles(true_scaffold):
-        return 0.8
-
-    # Check fingerprint similarity
-    pred_fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(pred_mol, 2, 1024)
-    true_fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(true_mol, 2, 1024)
-
-    tanimoto = DataStructs.TanimotoSimilarity(pred_fp, true_fp)
-
-    # Check if functional groups are present
-    pred_groups = rdMolDescriptors.CalcNumRotatableBonds(pred_mol)
-    true_groups = rdMolDescriptors.CalcNumRotatableBonds(true_mol)
-
-    # Calculate similarity based on rotatable bonds
-    # Using max to avoid division by zero
-    rb_similarity = 1.0 - abs(pred_groups - true_groups) / (
-        max(pred_groups, true_groups, 1)
-    )
-
-    final_score = 0.7 * tanimoto + 0.3 * rb_similarity
-    return max(0.0, min(final_score, 1.0))
+    return 0.0

--- a/tasks/spectra_elu_hard/spectra_elu_hard/score.py
+++ b/tasks/spectra_elu_hard/spectra_elu_hard/score.py
@@ -1,7 +1,5 @@
 import modal
-from rdkit import Chem, DataStructs
-from rdkit.Chem import rdMolDescriptors
-from rdkit.Chem.Scaffolds import MurckoScaffold
+from rdkit import Chem
 
 get_isomeric_smiles = modal.Function.from_name("chemenv", "get_isomeric_smiles_pubchem")
 
@@ -17,12 +15,6 @@ def score_molecule_similarity(prediction: str, ground_truth: str) -> float:
     Returns:
         float: Score between 0.0 and 1.0 based on similarity
     """
-    # Convert possible names into SMILES
-    try:
-        prediction = get_isomeric_smiles.remote(prediction)
-    except Exception:
-        return 0.0
-
     try:
         pred_mol = Chem.MolFromSmiles(prediction)
     except Exception:
@@ -41,27 +33,4 @@ def score_molecule_similarity(prediction: str, ground_truth: str) -> float:
     if Chem.MolToSmiles(pred_mol) == Chem.MolToSmiles(true_mol):
         return 1.0
 
-    # Check scaffold match
-    pred_scaffold = MurckoScaffold.GetScaffoldForMol(pred_mol)
-    true_scaffold = MurckoScaffold.GetScaffoldForMol(true_mol)
-    if Chem.MolToSmiles(pred_scaffold) == Chem.MolToSmiles(true_scaffold):
-        return 0.8
-
-    # Check fingerprint similarity
-    pred_fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(pred_mol, 2, 1024)
-    true_fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(true_mol, 2, 1024)
-
-    tanimoto = DataStructs.TanimotoSimilarity(pred_fp, true_fp)
-
-    # Check if functional groups are present
-    pred_groups = rdMolDescriptors.CalcNumRotatableBonds(pred_mol)
-    true_groups = rdMolDescriptors.CalcNumRotatableBonds(true_mol)
-
-    # Calculate similarity based on rotatable bonds
-    # Using max to avoid division by zero
-    rb_similarity = 1.0 - abs(pred_groups - true_groups) / (
-        max(pred_groups, true_groups, 1)
-    )
-
-    final_score = 0.7 * tanimoto + 0.3 * rb_similarity
-    return max(0.0, min(final_score, 1.0))
+    return 0.0


### PR DESCRIPTION
## Summary by Sourcery

Simplify and correct molecule similarity scoring in both spectra tasks by removing partial-match heuristics and awarding full points only for exact SMILES matches.

Bug Fixes:
- Fix scoring to return 1.0 only for exact matches and default to 0.0 otherwise.

Enhancements:
- Remove scaffold, fingerprint and rotatable bond–based similarity calculations and related RDKit imports.
- Add an early string-level equality check in the easy task to short-circuit exact matches.