### PR TITLE
feat: modify the code to handle the different levels of extended docstrings

### DIFF
--- a/src/corral/agents/llm_planner.py
+++ b/src/corral/agents/llm_planner.py
@@ -1,11 +1,17 @@
-from promptstore import PromptStore
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from promptstore import PromptStore
+
+    from corral.evaluate import BenchmarkInterface
 
 from corral.agents.base_agent import BaseAgent
 from corral.agents.prompt_utils import create_prompt
 from corral.agents.react import ReActAgent
 from corral.agents.tool_calling import ToolCallingAgent
 from corral.agents.utils import LiteLLMMessage
-from corral.evaluate import BenchmarkInterface
 
 
 class LLMPlanner(BaseAgent):
@@ -97,6 +103,7 @@ class LLMPlanner(BaseAgent):
         history: list[LiteLLMMessage] | None = None,
         task_prompt: str | None = None,
         examples: list[str] | None = None,
+        sections: list[str] | None = None,
     ) -> str:
         """Run the LLM planner agent
 
@@ -106,11 +113,12 @@ class LLMPlanner(BaseAgent):
             history (List[LiteLLMMessage], optional): The history items to include. Defaults to None.
             task_prompt (str, optional): The task prompt to use. Defaults to None.
             examples (List[str], optional): List with the few-shot examples to use. Defaults to None.
+            sections (list[str], optional): List of sections describing the level of detail in the tools description. Defaults to None.
 
         Returns:
             str: The final answer to the task
         """
-        tools = interface.get_available_tools_for_task(task_id)
+        tools = interface.get_available_tools_for_task(task_id, sections)
 
         if task_prompt is None:
             task_guide = interface.get_task_prompt(task_id)

--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -105,6 +105,7 @@ class ToolCallingAgent(BaseAgent):
         history: list[LiteLLMMessage] | None = None,
         task_prompt: str | None = None,
         examples: list[str] | None = None,
+        sections: list[str] | None = None,
     ) -> str:
         """Run the agent to solve the task
 
@@ -114,12 +115,13 @@ class ToolCallingAgent(BaseAgent):
             history (list[LiteLLMMessage]], optional): The history items to include. Defaults to None.
             task_prompt (str, optional): The task prompt to use. Defaults to None.
             examples (list[str], optional): List with the few-shot examples to use. Defaults to None.
+            sections (list[str], optional): List of sections describing the level of detail in the tools description. Defaults to None.
 
         Returns:
             str: The final answer to the task
         """
         tools = convert_to_openai_tool_format(
-            interface.get_available_tools_for_task(task_id)
+            interface.get_available_tools_for_task(task_id, sections)
         )
         if task_prompt is None:
             task_guide = interface.get_task_prompt(task_id)

--- a/src/corral/base.py
+++ b/src/corral/base.py
@@ -105,9 +105,20 @@ class Tool:
     TODO: add descriptions of the arguments of the class, i.e., name, description, arguments
     """
 
-    def __init__(self, name: str, description: str, arguments: list[ToolArgument]):
+    def __init__(
+        self,
+        name: str,
+        description: str | dict[str, str],
+        arguments: list[ToolArgument],
+    ):
         self.name = name
-        self.description = description
+        # Handle both old string format and new sections dict format
+        if isinstance(description, dict):
+            self.sections = description
+            self.description = description.get("BRIEF", "")
+        else:
+            self.sections = {"BRIEF": description}
+            self.description = description
         self.arguments = arguments
 
     def validate_arguments(
@@ -171,7 +182,7 @@ class ModalTool(Tool):
         self,
         modal_func: Callable,
         name: str,
-        description: str,
+        description: str | dict[str, str],
         arguments: list[ToolArgument],
     ):
         super().__init__(
@@ -254,23 +265,34 @@ class Environment(ABC):
         """Add a tool to the environment"""
         self.tools[tool.name] = tool
 
-    def get_available_tools(self) -> list[dict[str, str | list[ToolArgument]]]:
-        """Get list of available tools with their descriptions and arguments.
+    def get_available_tools(
+        self, keywords: list[str]
+    ) -> list[dict[str, str | list[ToolArgument]]]:
+        """Get list of available tools with concatenated section descriptions.
+
+        Args:
+            keywords (list[str]): List of section keywords to concatenate for descriptions
 
         Returns:
             list[dict[str, str | list[ToolArgument]]]: A list of dictionaries where each dictionary contains:
                 - 'name': the tool's name as a string.
-                - 'description': a string describing the tool.
-                - 'arguments': a list of ToolArgument objects representing the tool's arguments.
+                - 'description': concatenated sections specified by keywords, joined by double newlines.
+                - 'arguments': a string of comma-separated argument names.
         """
-        return [
-            {
-                "name": t.name,
-                "description": t.description,
-                "arguments": ", ".join(arg.name for arg in t.arguments),
-            }
-            for t in self.tools.values()
-        ]
+        tools_info = []
+        for tool in self.tools.values():
+            # Get concatenated description using the existing method
+            description = self.get_tool_description_by_keyword(tool.name, keywords)
+
+            tools_info.append(
+                {
+                    "name": tool.name,
+                    "description": description,
+                    "arguments": ", ".join(arg.name for arg in tool.arguments),
+                }
+            )
+
+        return tools_info
 
     def get_tools_guide(self) -> str:
         """Generate a guide for the available tools"""
@@ -305,6 +327,45 @@ class Environment(ABC):
 
 {tools_guide}
 """
+
+    def get_tool_description_by_keyword(
+        self, tool_name: str, keyword: str | list[str]
+    ) -> str:
+        """Get specific section(s) of a tool's description by keyword(s).
+
+        Args:
+            tool_name (str): The name of the tool
+            keyword (Union[str, list[str]]): The keyword/section(s) to retrieve (e.g., 'BRIEF', 'DETAILED', 'EXAMPLES')
+                                           If a list is provided, sections are concatenated with double newlines
+                                           If "ALL" is included in keywords, all sections are returned
+
+        Returns:
+            str: The requested section content(s), or an error message if not found
+        """
+        if tool_name not in self.tools:
+            return f"Tool '{tool_name}' not found"
+
+        tool = self.tools[tool_name]
+        if not hasattr(tool, "sections") or not isinstance(tool.sections, dict):
+            return f"Tool '{tool_name}' does not have sectioned documentation"
+
+        # Handle single keyword (backward compatibility)
+        keywords = [keyword] if isinstance(keyword, str) else keyword
+
+        # Handle "ALL" keyword - return all sections
+        if "ALL" in keywords:
+            sections_content = list(tool.sections.values())
+            return "\n\n".join(sections_content)
+
+        # Validate all keywords exist
+        missing_keywords = [k for k in keywords if k not in tool.sections]
+        if missing_keywords:
+            available_keywords = list(tool.sections.keys())
+            return f"Keyword(s) {missing_keywords} not found for tool '{tool_name}'. Available keywords: {available_keywords}"
+
+        # Get and concatenate sections
+        sections_content = [tool.sections[k] for k in keywords]
+        return "\n\n".join(sections_content)
 
     def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> ToolCall:
         """Execute a tool and record the call with enhanced error handling"""

--- a/src/corral/evaluate.py
+++ b/src/corral/evaluate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,11 +37,17 @@ class BenchmarkInterface:
         except Exception:
             return False
 
-    def get_available_tools_for_task(self, task_id: str) -> dict[str, Any]:
+    def get_available_tools_for_task(
+        self, task_id: str, sections: list[str] | None = None
+    ) -> dict[str, Any]:
         """Get list of available tools for a task"""
-        response = requests.get(f"{self.base_url}/tasks/{task_id}/tools")
+        # Send keywords in request body as expected by server
+        keywords = sections if sections is not None else ["BRIEF"]
+        data = {"keywords": keywords}
+
+        response = requests.post(f"{self.base_url}/tasks/{task_id}/tools", json=data)
         response.raise_for_status()
-        return response.json()
+        return response.json()["tools"]
 
     def get_task_guide(self, task_id: str) -> str:
         """Get complete guide for task including tools"""
@@ -234,9 +242,7 @@ class MatAgentBenchmark:
         ]
 
         logger.info(
-            f"Independent execution: {
-                len(completed_tasks)} completed, {
-                len(remaining_tasks)} remaining"
+            f"Independent execution: {len(completed_tasks)} completed, {len(remaining_tasks)} remaining"
         )
 
         for task_id in remaining_tasks:

--- a/src/corral/server.py
+++ b/src/corral/server.py
@@ -46,12 +46,21 @@ def create_benchmark_server(environments: dict[str, Environment]) -> FastAPI:
             raise HTTPException(status_code=404, detail="Task not found")
         return {"prompt": environments[task_id].get_tools_guide()}
 
-    @app.get("/tasks/{task_id}/tools")
-    def get_available_tools(task_id: str):
-        """Get available tools for this task"""
+    @app.post("/tasks/{task_id}/tools")
+    def get_available_tools(task_id: str, keywords: dict):
+        """Get available tools with concatenated section descriptions"""
         if task_id not in environments:
             raise HTTPException(status_code=404, detail="Task not found")
-        return {"tools": environments[task_id].get_available_tools()}
+
+        keyword_list = keywords.get("keywords", ["BRIEF"])
+        if not keyword_list:
+            raise HTTPException(status_code=400, detail="Keywords list is required")
+
+        return {
+            "tools": environments[task_id].get_available_tools_with_sections(
+                keyword_list
+            )
+        }
 
     @app.post("/tasks/{task_id}/tools/execute")
     def execute_tool(task_id: str, request: ToolRequest):

--- a/src/corral/utils.py
+++ b/src/corral/utils.py
@@ -147,7 +147,7 @@ def parse_complex_docstring(doc: str) -> tuple[dict[str, str], list[ToolArgument
     return sections, arguments
 
 
-def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
+def parse_docstring(func: Callable) -> tuple[dict[str, str], list[ToolArgument]]:
     """Parse function docstring to get description and arguments.
 
     This function extracts the description and arguments from a function's docstring.
@@ -157,8 +157,8 @@ def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
         func (Callable): The function to parse docstring from
 
     Returns:
-        tuple[dict, list[ToolArgument]]: (description, arguments) where description is a string and
-               arguments is a list of ToolArgument objects
+        tuple[dict[str, str], list[ToolArgument]]: (sections, arguments) where sections is a dict
+               mapping section names to content and arguments is a list of ToolArgument objects
 
     Raises:
         ValueError: If the docstring is missing or doesn't have an Args section
@@ -172,13 +172,13 @@ def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
 
     else:
         # Split docstring into sections
-        sections = doc.split("\n\n")
-        description = sections[0].strip()
+        doc_sections = doc.split("\n\n")
+        description = doc_sections[0].strip()
         sections = {"BRIEF": description}
 
         # Find Args section
         args_section = None
-        for section in sections:
+        for section in doc_sections:
             if section.strip().startswith("Args:"):
                 args_section = section.strip()
                 break
@@ -245,7 +245,7 @@ def parse_docstring(func: Callable) -> tuple[str, list[ToolArgument]]:
             )
         )
 
-    return sections["BRIEF"], arguments
+    return sections, arguments
 
 
 def tool(func: Callable) -> Tool:
@@ -309,7 +309,7 @@ def tool(func: Callable) -> Tool:
         )
 
     try:
-        description, arguments = parse_docstring(func)
+        sections, arguments = parse_docstring(func)
     except Exception as e:
         raise ValueError(
             f"Error parsing docstring for function {func.__name__}: {e!s}. "
@@ -328,7 +328,7 @@ def tool(func: Callable) -> Tool:
     class FunctionTool(Tool):
         def __init__(self):
             super().__init__(
-                name=func.__name__, description=description, arguments=arguments
+                name=func.__name__, description=sections, arguments=arguments
             )
 
         def execute(self, **kwargs):
@@ -384,12 +384,12 @@ def modal_tool(
 
     def decorator(func: Callable):
         modal_func = create_modal_function(func, app, **modal_kwargs)
-        description, arguments = parse_docstring(func)
+        sections, arguments = parse_docstring(func)
 
         tool_instance = ModalTool(
             modal_func=modal_func,
             name=func.__name__,
-            description=description,
+            description=sections,
             arguments=arguments,
         )
 
@@ -1074,4 +1074,5 @@ from the file contents, such as specific parameters or coefficients used in the 
 it relies solely on the file name for metadata extraction.
 [/LIMITATIONS]
 """
-    chunks = parse_docstring(example_text)
+    # This is invalid - parse_docstring expects a function, not a string
+    # chunks = parse_docstring(example_text)


### PR DESCRIPTION
…ocstrings

## Summary by Sourcery

Enable structured docstring support by extracting named sections and allowing clients to request specific or combined sections for tool descriptions, and adapt parsing, server endpoints, client calls, and agent workflows accordingly.

New Features:
- Accept tool descriptions as a dict of named sections and default to the BRIEF section
- Expose a new get_tool_description_by_keyword method to retrieve specific or all docstring sections
- Allow clients to specify section keywords to concatenate when listing available tools

Enhancements:
- Update parse_docstring to return a sections dict instead of a plain string
- Change /tasks/{task_id}/tools to POST with a keywords list and adjust the evaluate client to use it
- Propagate a sections parameter through LLMPlanner and ToolCallingAgent to fetch detailed tool descriptions based on keywords