### PR TITLE
feat: add chembench runs

### DIFF
--- a/tasks/chembench/chembench/env.py
+++ b/tasks/chembench/chembench/env.py
@@ -1,6 +1,9 @@
 import os
 from typing import Any
 
+import fire
+import uvicorn
+from datasets import load_dataset
 from dotenv import load_dotenv
 from loguru import logger
 from tools import (
@@ -8,17 +11,17 @@ from tools import (
     get_element_info,
     get_formula_from_smiles,
     get_functional_groups,
-    get_ghs_classification_pubchem,
+    # get_ghs_classification_pubchem,
     get_h_nmr_spectra_pubchem,
     get_ms_spectra_pubchem,
     get_number_of_isomers,
     get_pka_from_smiles,
     get_smiles_from_name,
-    online_search,
-    relevant_pubchem_sections,
-    search_clinical_trials_by_drug,
-    search_clinical_trials_by_query,
-    search_materials_compatibility,
+    # online_search,
+    # relevant_pubchem_sections,
+    # search_clinical_trials_by_drug,
+    # search_clinical_trials_by_query,
+    # search_materials_compatibility,
     simulate_spectra,
     smiles_to_name,
 )
@@ -37,28 +40,29 @@ from corral.io import (
     ReadFileTool,
     WriteFileTool,
 )
+from corral.server import create_benchmark_server
 
 load_dotenv("../.env", override=True)
 BASE_WORK_DIR = os.environ.get("CORRAL_WORK_DIR", "../CORRAL_WORK_DIR/temp")
 
 _CHEMBENCH_TOOLS = [
-    online_search,
-    relevant_pubchem_sections,
+    # online_search,
+    # relevant_pubchem_sections,
     smiles_to_name,
     get_smiles_from_name,
     get_pka_from_smiles,
     get_formula_from_smiles,
     get_element_info,
     get_number_of_isomers,
-    get_ghs_classification_pubchem,
+    # get_ghs_classification_pubchem,
     get_ms_spectra_pubchem,
     get_h_nmr_spectra_pubchem,
     get_c_nmr_spectra_pubchem,
     simulate_spectra,
     get_functional_groups,
-    search_clinical_trials_by_query,
-    search_clinical_trials_by_drug,
-    search_materials_compatibility,
+    # search_clinical_trials_by_query,
+    # search_clinical_trials_by_drug,
+    # search_materials_compatibility,
 ]
 
 
@@ -96,6 +100,7 @@ class ChemBenchEnvironment(Environment):
         benchmark: ChemBenchmark,
         prompter: PrompterBuilder,
         tools: dict[str, Any] | None = None,
+        work_dir: str = "chembench_env",
     ):
         self.task_id = task_id
         self.tasks = tasks
@@ -106,7 +111,7 @@ class ChemBenchEnvironment(Environment):
         self.all_prompts = []
         self.all_score_maps = []
 
-        super().__init__(task_id)
+        super().__init__(task_id, base_work_dir=work_dir)
         # Add multiple tools
         for tool in _CHEMBENCH_TOOLS:
             self.add_tool(tool)
@@ -185,8 +190,44 @@ def get_all_tasks(benchmark: ChemBenchmark) -> list[Task]:
     return tasks
 
 
-def main():
+def main(port: int = 8000, work_dir: str = "chembench_env"):
     benchmark = ChemBenchmark.from_huggingface(report_dir="../reports", verbose=True)
+
+    # Load the dataset from HuggingFace
+    logger.info("Loading ChemBench dataset from HuggingFace...")
+
+    # Available configs (excluding chemical_preference as requested)
+    configs = [
+        "analytical_chemistry",
+        "general_chemistry",
+        "inorganic_chemistry",
+        "materials_science",
+        "organic_chemistry",
+        "physical_chemistry",
+        "technical_chemistry",
+        "toxicity_and_safety",
+    ]
+
+    # Create a mapping from uuid to dataset row for quick lookup
+    uuid_to_row = {}
+
+    for config in configs:
+        logger.info(f"Loading config: {config}")
+        try:
+            dataset = load_dataset("jablonkagroup/ChemBench", config)
+
+            # Process all splits in this config
+            for split in dataset:
+                for row in dataset[split]:
+                    uuid_to_row[row["uuid"]] = row
+
+        except Exception as e:
+            logger.error(f"Failed to load config {config}: {e}")
+            continue
+
+    logger.info(
+        f"Loaded {len(uuid_to_row)} tasks from dataset (excluding chemical_preference config)"
+    )
 
     prompter = PrompterBuilder.from_model_object(
         model=Model(),
@@ -210,16 +251,36 @@ def main():
             "requires-reasoning" in task._keywords
             or "requires-calculation" in task._keywords
         ):
-            logger.info(f"Skipping task {task._uuid} due to reasoning requirement")
+            logger.info(f"Task {task._uuid} fits in the reasoning requirement")
 
-            environments[task._uuid] = ChemBenchEnvironment(
-                task._uuid, [task], benchmark, prompter, tools=fs_tools
-            )
+            # Check if task exists in dataset and has valid humansubset flags
+            if task._uuid in uuid_to_row:
+                row = uuid_to_row[task._uuid]
+                if row.get("in_humansubset_w_tool", False) or row.get(
+                    "in_humansubset_wo_tool", False
+                ):
+                    logger.info(
+                        f"Task {task._uuid} is in human subset, creating environment"
+                    )
+                    environments[task._uuid] = ChemBenchEnvironment(
+                        task._uuid,
+                        [task],
+                        benchmark,
+                        prompter,
+                        tools=fs_tools,
+                        work_dir=work_dir,
+                    )
+                else:
+                    logger.info(f"Task {task._uuid} is not in human subset, skipping")
+            else:
+                logger.warning(f"Task {task._uuid} not found in dataset, skipping")
 
-    # # Create and run server
-    # app = create_benchmark_server(environments)
-    # uvicorn.run(app, host="0.0.0.0", port=8000)
+    logger.info(f"Created {len(environments)} environments")
+
+    # Create and run server
+    app = create_benchmark_server(environments)
+    uvicorn.run(app, host="0.0.0.0", port=port)
 
 
 if __name__ == "__main__":
-    main()
+    fire.Fire(main)

--- a/tests/agents/__init__.py
+++ b/tests/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for corral agents."""

--- a/tests/agents/test_base_agent.py
+++ b/tests/agents/test_base_agent.py
@@ -1,0 +1,525 @@
+"""Tests for the BaseAgent class."""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from litellm.types.utils import Message
+from promptstore import PromptStore
+
+from corral.agents.base_agent import BaseAgent
+from corral.agents.utils import LiteLLMMessage
+from corral.evaluate import BenchmarkInterface
+
+
+class MockPrompt:
+    """Mock prompt class that implements the required fill method."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+    def fill(self, replacements: dict[str, Any]) -> str:
+        """Fill the prompt with replacements."""
+        result = self.content
+        for key, value in replacements.items():
+            result = result.replace(f"{{{{{key}}}}}", str(value))
+        return result
+
+
+class ConcreteAgent(BaseAgent):
+    """Concrete implementation of BaseAgent for testing purposes."""
+
+    def run(
+        self,
+        interface: BenchmarkInterface,
+        task_id: str,
+        history: list[LiteLLMMessage] | None = None,
+        task_prompt: str | None = None,
+        examples: list[str] | None = None,
+    ) -> str:
+        """Simple implementation for testing."""
+        return "test_answer"
+
+
+@pytest.fixture()
+def mock_prompt_store():
+    """Mock PromptStore for testing."""
+    store = Mock(spec=PromptStore)
+    store.get.return_value = MockPrompt("Test prompt: {{task_guide}}")
+    return store
+
+
+@pytest.fixture()
+def mock_benchmark_interface():
+    """Mock BenchmarkInterface for testing."""
+    return Mock(spec=BenchmarkInterface)
+
+
+@pytest.fixture()
+def concrete_agent(mock_prompt_store):
+    """Create a concrete agent instance for testing."""
+    return ConcreteAgent(
+        model="test-model",
+        prompt_store=mock_prompt_store,
+        temperature=0.5,
+        max_iterations=5,
+    )
+
+
+class TestBaseAgentInitialization:
+    """Test BaseAgent initialization."""
+
+    def test_default_initialization(self):
+        """Test agent initialization with default values."""
+        agent = ConcreteAgent()
+
+        assert agent.model == "openai/gpt-4o"
+        assert agent.max_iterations == 10
+        assert agent.api_endpoint is None
+        assert agent.temperature == 0.7
+        assert agent.messages == []
+        assert agent.token_usage == []
+
+    def test_custom_initialization(self, mock_prompt_store):
+        """Test agent initialization with custom values."""
+        agent = ConcreteAgent(
+            model="custom-model",
+            max_iterations=15,
+            api_endpoint="https://custom.endpoint",
+            temperature=0.3,
+            prompt_store=mock_prompt_store,
+        )
+
+        assert agent.model == "custom-model"
+        assert agent.max_iterations == 15
+        assert agent.api_endpoint == "https://custom.endpoint"
+        assert agent.temperature == 0.3
+        assert agent.store == mock_prompt_store
+
+    def test_initialization_with_custom_prompts(self, mock_prompt_store):
+        """Test initialization with custom prompt objects."""
+        system_prompt = MockPrompt("Custom system prompt")
+        user_prompt = MockPrompt("Custom user prompt")
+        extractor_prompt = MockPrompt("Custom extractor prompt")
+
+        agent = ConcreteAgent(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            extractor_prompt=extractor_prompt,
+            prompt_store=mock_prompt_store,
+        )
+
+        assert agent.system_prompt == system_prompt
+        assert agent.user_prompt == user_prompt
+        assert agent.extractor_prompt == extractor_prompt
+
+    def test_initialization_with_string_prompts(self, mock_prompt_store):
+        """Test initialization with string prompts."""
+        system_prompt = "You are a helpful assistant"
+        user_prompt = "Task: {{task_guide}}"
+        extractor_prompt = "Extract: {{answer}}"
+
+        agent = ConcreteAgent(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            extractor_prompt=extractor_prompt,
+            prompt_store=mock_prompt_store,
+        )
+
+        assert agent.system_prompt == system_prompt
+        assert agent.user_prompt == user_prompt
+        assert agent.extractor_prompt == extractor_prompt
+
+    @patch("corral.agents.base_agent.importlib.resources.path")
+    def test_default_prompt_store_creation(self, mock_resources_path):
+        """Test that default prompt store is created when none provided."""
+        mock_resources_path.return_value.__enter__.return_value = "/mock/path"
+
+        with patch("corral.agents.base_agent.PromptStore") as mock_promptstore:
+            mock_promptstore.assert_called_once_with("/mock/path/prompts")
+
+    def test_kwargs_passed_through(self, mock_prompt_store):
+        """Test that additional kwargs are stored."""
+        agent = ConcreteAgent(
+            prompt_store=mock_prompt_store, custom_arg="test_value", another_arg=42
+        )
+
+        assert agent.kwargs["custom_arg"] == "test_value"
+        assert agent.kwargs["another_arg"] == 42
+
+
+class TestBaseAgentLLMResponse:
+    """Test BaseAgent LLM response handling."""
+
+    @patch("corral.agents.base_agent.llm_call")
+    def test_get_llm_response_success(self, mock_llm_call, concrete_agent):
+        """Test successful LLM response."""
+        mock_response = Mock()
+        mock_response.content = "Test response"
+        mock_usage = {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        }
+        mock_llm_call.return_value = (mock_response, mock_usage)
+
+        concrete_agent.messages = [{"role": "user", "content": "Test message"}]
+
+        response = concrete_agent.get_llm_response()
+
+        assert response == mock_response
+        assert len(concrete_agent.token_usage) == 1
+        assert concrete_agent.token_usage[0] == mock_usage
+
+        mock_llm_call.assert_called_once_with(
+            model="test-model",
+            messages=concrete_agent.messages,
+            tools=None,
+            temperature=0.5,
+            api_endpoint=None,
+            return_usage=True,
+        )
+
+    @patch("corral.agents.base_agent.llm_call")
+    def test_get_llm_response_with_tools(self, mock_llm_call, concrete_agent):
+        """Test LLM response with tools."""
+        mock_response = Mock()
+        mock_usage = {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        }
+        mock_llm_call.return_value = (mock_response, mock_usage)
+
+        tools = [{"type": "function", "function": {"name": "test_tool"}}]
+        concrete_agent.messages = [{"role": "user", "content": "Test message"}]
+
+        response = concrete_agent.get_llm_response(tools=tools)
+
+        assert response == mock_response
+        mock_llm_call.assert_called_once_with(
+            model="test-model",
+            messages=concrete_agent.messages,
+            tools=tools,
+            temperature=0.5,
+            api_endpoint=None,
+            return_usage=True,
+        )
+
+    @patch("corral.agents.base_agent.llm_call")
+    def test_get_llm_response_rate_limit_error(self, mock_llm_call, concrete_agent):
+        """Test handling of rate limit errors."""
+        from unittest.mock import Mock
+
+        import openai
+
+        # Create a mock response for the exception
+        mock_response = Mock()
+        mock_response.status_code = 429
+        mock_body = {"error": {"message": "Rate limit exceeded"}}
+
+        mock_llm_call.side_effect = openai.RateLimitError(
+            "Rate limit exceeded", response=mock_response, body=mock_body
+        )
+
+        concrete_agent.messages = [
+            {"role": "user", "content": "A very long message " * 100},
+            {
+                "role": "user",
+                "content": "Another user message",
+            },  # No assistant message to break the loop
+        ]
+
+        response = concrete_agent.get_llm_response()
+
+        assert isinstance(response, Message)
+        assert response.role == "user"
+        assert "RateLimitError" in response.content
+        # Check that long messages are truncated (processes in reverse order)
+        assert len(concrete_agent.messages[0]["content"]) <= 103  # 100 + "..."
+
+    @patch("corral.agents.base_agent.llm_call")
+    def test_get_llm_response_context_window_error(self, mock_llm_call, concrete_agent):
+        """Test handling of context window exceeded errors."""
+        import litellm
+
+        mock_llm_call.side_effect = litellm.ContextWindowExceededError(
+            "Context window exceeded", model="test-model", llm_provider="test-provider"
+        )
+
+        concrete_agent.messages = [
+            {"role": "user", "content": "Test message"},
+            {"role": "assistant", "content": "Response"},
+        ]
+
+        response = concrete_agent.get_llm_response()
+
+        assert isinstance(response, Message)
+        assert response.role == "user"
+        assert "ContextWindowExceededError" in response.content
+
+    @patch("corral.agents.base_agent.llm_call")
+    def test_get_llm_response_generic_error(self, mock_llm_call, concrete_agent):
+        """Test handling of generic errors."""
+        mock_llm_call.side_effect = Exception("Generic error")
+
+        with pytest.raises(Exception, match="Generic error"):
+            concrete_agent.get_llm_response()
+
+
+class TestBaseAgentRunAgent:
+    """Test BaseAgent run_agent method."""
+
+    def test_run_agent_success(self, concrete_agent, mock_benchmark_interface):
+        """Test successful run_agent execution."""
+        with (
+            patch.object(concrete_agent, "run", return_value="test_answer") as mock_run,
+            patch("corral.agents.base_agent.llm_call") as mock_llm_call,
+        ):
+            mock_response = Mock()
+            mock_response.content = "extracted_answer"
+            mock_llm_call.return_value = mock_response
+
+            concrete_agent.messages = [
+                {"role": "user", "content": "Test task"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface,
+                task_id="test_task",
+                history=[],
+                task_prompt="Test prompt",
+                examples=["example1", "example2"],
+            )
+
+            assert result == "extracted_answer"
+            assert isinstance(usage, dict)
+            assert "prompt_tokens" in usage
+            assert "completion_tokens" in usage
+            assert "total_tokens" in usage
+
+            mock_run.assert_called_once_with(
+                mock_benchmark_interface,
+                "test_task",
+                [],
+                "Test prompt",
+                ["example1", "example2"],
+            )
+
+    def test_run_agent_with_system_message(
+        self, concrete_agent, mock_benchmark_interface
+    ):
+        """Test run_agent with system message."""
+        # Set up a proper extractor prompt
+        concrete_agent.extractor_prompt = MockPrompt(
+            "Extract from message: {{message}}"
+        )
+
+        with (
+            patch.object(concrete_agent, "run", return_value="test_answer"),
+            patch("corral.agents.base_agent.llm_call") as mock_llm_call,
+        ):
+            mock_response = Mock()
+            mock_response.content = "extracted_answer"
+            mock_llm_call.return_value = mock_response
+
+            concrete_agent.messages = [
+                {"role": "system", "content": "System message"},
+                {"role": "user", "content": "Test task"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface, task_id="test_task"
+            )
+
+            # Check that extractor prompt was called with both system and user content
+            call_args = mock_llm_call.call_args
+            prompt_content = call_args[1]["messages"][0]["content"]
+            assert "System message" in prompt_content
+            assert "Test task" in prompt_content
+
+    def test_run_agent_with_error_in_answer(
+        self, concrete_agent, mock_benchmark_interface
+    ):
+        """Test run_agent when answer contains error."""
+        with patch.object(
+            concrete_agent, "run", return_value="Error: Something went wrong"
+        ):
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface, task_id="test_task"
+            )
+
+            assert "Error: Something went wrong" in result
+            assert isinstance(usage, dict)
+
+    def test_run_agent_with_exception(self, concrete_agent, mock_benchmark_interface):
+        """Test run_agent when run method raises exception."""
+        with patch.object(concrete_agent, "run", side_effect=Exception("Run failed")):
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface, task_id="test_task"
+            )
+
+            assert "Error running agent: Run failed" in result
+            assert isinstance(usage, dict)
+
+    def test_run_agent_verbose_mode(self, concrete_agent, mock_benchmark_interface):
+        """Test run_agent in verbose mode."""
+        with (
+            patch.object(concrete_agent, "run", return_value="test_answer"),
+            patch("corral.agents.base_agent.llm_call") as mock_llm_call,
+            patch("corral.agents.base_agent.save_agent_messages") as mock_save,
+        ):
+            mock_response = Mock()
+            mock_response.content = "extracted_answer"
+            mock_llm_call.return_value = mock_response
+
+            concrete_agent.messages = [
+                {"role": "user", "content": "Test task"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface,
+                task_id="test_task",
+                verbose=True,
+            )
+
+            mock_save.assert_called_once()
+            call_args = mock_save.call_args
+            assert call_args[0][0] == concrete_agent.messages
+            assert call_args[0][1] == "test_task"
+            assert call_args[0][2] == "ConcreteAgent"
+
+    def test_run_agent_extractor_error(self, concrete_agent, mock_benchmark_interface):
+        """Test run_agent when extractor fails."""
+        with (
+            patch.object(concrete_agent, "run", return_value="test_answer"),
+            patch(
+                "corral.agents.base_agent.llm_call",
+                side_effect=Exception("Extractor failed"),
+            ),
+        ):
+            concrete_agent.messages = [
+                {"role": "user", "content": "Test task"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface, task_id="test_task"
+            )
+
+            assert result == "test_answer"  # Should return original answer
+            assert isinstance(usage, dict)
+
+
+class TestBaseAgentTokenUsage:
+    """Test BaseAgent token usage tracking."""
+
+    def test_get_total_token_usage_empty(self, concrete_agent):
+        """Test token usage calculation with no usage data."""
+        usage = concrete_agent.get_total_token_usage()
+
+        assert usage == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+    def test_get_total_token_usage_with_data(self, concrete_agent):
+        """Test token usage calculation with usage data."""
+        concrete_agent.token_usage = [
+            {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+            {"prompt_tokens": 200, "completion_tokens": 75, "total_tokens": 275},
+            {"prompt_tokens": 50, "completion_tokens": 25, "total_tokens": 75},
+        ]
+
+        usage = concrete_agent.get_total_token_usage()
+
+        assert usage == {
+            "prompt_tokens": 350,
+            "completion_tokens": 150,
+            "total_tokens": 500,
+        }
+
+    def test_get_total_token_usage_with_missing_keys(self, concrete_agent):
+        """Test token usage calculation with missing keys."""
+        concrete_agent.token_usage = [
+            {"prompt_tokens": 100, "total_tokens": 150},  # Missing completion_tokens
+            {"completion_tokens": 75, "total_tokens": 275},  # Missing prompt_tokens
+            {},  # Missing all keys
+        ]
+
+        usage = concrete_agent.get_total_token_usage()
+
+        assert usage == {
+            "prompt_tokens": 100,
+            "completion_tokens": 75,
+            "total_tokens": 425,
+        }
+
+    def test_reset_token_usage(self, concrete_agent):
+        """Test resetting token usage."""
+        concrete_agent.token_usage = [
+            {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
+        ]
+
+        concrete_agent.reset_token_usage()
+
+        assert concrete_agent.token_usage == []
+
+
+class TestBaseAgentAbstractMethods:
+    """Test BaseAgent abstract methods."""
+
+    def test_cannot_instantiate_base_agent(self):
+        """Test that BaseAgent cannot be instantiated directly."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            BaseAgent()
+
+    def test_concrete_agent_implements_run(
+        self, concrete_agent, mock_benchmark_interface
+    ):
+        """Test that concrete agent implements run method."""
+        result = concrete_agent.run(
+            interface=mock_benchmark_interface, task_id="test_task"
+        )
+
+        assert result == "test_answer"
+
+
+class TestBaseAgentPromptHandling:
+    """Test BaseAgent prompt handling."""
+
+    def test_prompt_fill_method(self):
+        """Test that prompts have fill method."""
+        mock_prompt = MockPrompt("Test {{variable}}")
+        filled = mock_prompt.fill({"variable": "value"})
+
+        assert filled == "Test value"
+
+    def test_extractor_prompt_filling(self, concrete_agent, mock_benchmark_interface):
+        """Test that extractor prompt is filled correctly."""
+        concrete_agent.extractor_prompt = MockPrompt(
+            "Answer: {{answer}}, Message: {{message}}"
+        )
+
+        with (
+            patch.object(concrete_agent, "run", return_value="test_answer"),
+            patch("corral.agents.base_agent.llm_call") as mock_llm_call,
+        ):
+            mock_response = Mock()
+            mock_response.content = "extracted_answer"
+            mock_llm_call.return_value = mock_response
+
+            concrete_agent.messages = [
+                {"role": "user", "content": "Test task"},
+                {"role": "assistant", "content": "Test response"},
+            ]
+
+            result, usage = concrete_agent.run_agent(
+                interface=mock_benchmark_interface, task_id="test_task"
+            )
+
+            # Check that the extractor prompt was called with correct parameters
+            call_args = mock_llm_call.call_args
+            prompt_content = call_args[1]["messages"][0]["content"]
+            assert "Answer: test_answer" in prompt_content
+            assert "Message: " in prompt_content

--- a/tests/agents/test_prompt_utils.py
+++ b/tests/agents/test_prompt_utils.py
@@ -1,0 +1,266 @@
+"""Tests for the prompt_utils module."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from corral.agents.prompt_utils import (
+    StringPrompt,
+    build_user_content,
+    create_prompt,
+    get_prompt,
+)
+from corral.agents.utils import LiteLLMMessage
+
+
+class TestStringPrompt:
+    """Test cases for the StringPrompt class."""
+
+    def test_init(self):
+        """Test StringPrompt initialization."""
+        content = "Hello {name}!"
+        prompt = StringPrompt(content)
+        assert prompt.content == content
+
+    def test_fill_single_replacement(self):
+        """Test filling a prompt with a single replacement."""
+        prompt = StringPrompt("Hello {name}!")
+        result = prompt.fill({"name": "Alice"})
+        assert result == "Hello Alice!"
+
+    def test_fill_multiple_replacements(self):
+        """Test filling a prompt with multiple replacements."""
+        prompt = StringPrompt("Hello {name}, you are {age} years old!")
+        result = prompt.fill({"name": "Bob", "age": 30})
+        assert result == "Hello Bob, you are 30 years old!"
+
+    def test_fill_empty_replacements(self):
+        """Test filling a prompt with empty replacements."""
+        prompt = StringPrompt("Hello world!")
+        result = prompt.fill({})
+        assert result == "Hello world!"
+
+    def test_fill_with_non_string_values(self):
+        """Test filling a prompt with non-string values (should be converted to string)."""
+        prompt = StringPrompt("Count: {count}, Price: {price}")
+        result = prompt.fill({"count": 5, "price": 19.99})
+        assert result == "Count: 5, Price: 19.99"
+
+    def test_fill_missing_placeholder(self):
+        """Test filling a prompt where not all placeholders are provided."""
+        prompt = StringPrompt("Hello {name}, you are {age} years old!")
+        result = prompt.fill({"name": "Charlie"})
+        assert result == "Hello Charlie, you are {age} years old!"
+
+    def test_fill_extra_replacements(self):
+        """Test filling a prompt with extra replacements that don't match placeholders."""
+        prompt = StringPrompt("Hello {name}!")
+        result = prompt.fill({"name": "David", "extra": "ignored"})
+        assert result == "Hello David!"
+
+
+class TestGetPrompt:
+    """Test cases for the get_prompt function."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_store = Mock()
+        self.mock_prompt = Mock()
+        self.mock_prompt.fill = Mock(return_value="filled content")
+        self.mock_store.get = Mock(return_value=self.mock_prompt)
+
+    def test_get_prompt_with_none_input_and_default_uuid(self):
+        """Test getting prompt with None input and valid default UUID."""
+        result = get_prompt(self.mock_store, None, "test-uuid")
+        assert result == self.mock_prompt
+        self.mock_store.get.assert_called_once_with("test-uuid")
+
+    def test_get_prompt_with_none_input_and_none_default_uuid(self):
+        """Test getting prompt with None input and None default UUID raises ValueError."""
+        with pytest.raises(
+            ValueError, match="default_uuid cannot be None when prompt_input is None"
+        ):
+            get_prompt(self.mock_store, None, None)
+
+    def test_get_prompt_with_string_input(self):
+        """Test getting prompt with string input creates StringPrompt."""
+        result = get_prompt(self.mock_store, "test content", "unused-uuid")
+        assert isinstance(result, StringPrompt)
+        assert result.content == "test content"
+        self.mock_store.get.assert_not_called()
+
+    def test_get_prompt_with_existing_prompt_object(self):
+        """Test getting prompt with existing prompt object returns it unchanged."""
+        existing_prompt = Mock()
+        result = get_prompt(self.mock_store, existing_prompt, "unused-uuid")
+        assert result is existing_prompt
+        self.mock_store.get.assert_not_called()
+
+
+class TestCreatePrompt:
+    """Test cases for the create_prompt function."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_system_prompt = Mock()
+        self.mock_user_prompt = Mock()
+        self.mock_user_prompt.fill = Mock(return_value="filled user content")
+
+    def test_create_prompt_basic(self):
+        """Test creating a basic prompt with system and user prompts."""
+        result = create_prompt(
+            self.mock_system_prompt, self.mock_user_prompt, "test task guide"
+        )
+
+        assert len(result) == 2
+        assert result[0].get("role") == "system"
+        assert result[0].get("content") == self.mock_system_prompt
+        assert result[1].get("role") == "user"
+        assert result[1].get("content") == "filled user content"
+
+    def test_create_prompt_with_history(self):
+        """Test creating a prompt with message history."""
+        history = [
+            LiteLLMMessage(role="user", content="previous message"),
+            LiteLLMMessage(role="assistant", content="previous response"),
+        ]
+
+        result = create_prompt(
+            self.mock_system_prompt,
+            self.mock_user_prompt,
+            "test task guide",
+            history=history,
+        )
+
+        assert len(result) == 4
+        assert result[0].get("role") == "user"
+        assert result[0].get("content") == "previous message"
+        assert result[1].get("role") == "assistant"
+        assert result[1].get("content") == "previous response"
+        assert result[2].get("role") == "system"
+        assert result[2].get("content") == self.mock_system_prompt
+        assert result[3].get("role") == "user"
+        assert result[3].get("content") == "filled user content"
+
+    def test_create_prompt_with_none_system_prompt(self):
+        """Test creating a prompt with None system prompt."""
+        result = create_prompt(None, self.mock_user_prompt, "test task guide")
+
+        assert len(result) == 1
+        assert result[0].get("role") == "user"
+        assert result[0].get("content") == "filled user content"
+
+    def test_create_prompt_with_kwargs(self):
+        """Test creating a prompt with additional keyword arguments."""
+        # Verify that the user prompt's fill method was called with the extra parameter
+        expected_call_args = {
+            "task_guide": "test task guide",
+            "extra_param": "test value",
+        }
+        self.mock_user_prompt.fill.assert_called_once_with(expected_call_args)
+
+    def test_create_prompt_with_empty_history(self):
+        """Test creating a prompt with empty history list."""
+        result = create_prompt(
+            self.mock_system_prompt,
+            self.mock_user_prompt,
+            "test task guide",
+            history=[],
+        )
+
+        assert len(result) == 2
+        assert result[0].get("role") == "system"
+        assert result[1].get("role") == "user"
+
+
+class TestBuildUserContent:
+    """Test cases for the build_user_content function."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_user_prompt = Mock()
+        self.mock_user_prompt.fill = Mock(return_value="filled content")
+
+    def test_build_user_content_with_string_task_guide(self):
+        """Test building user content with string task guide."""
+        result = build_user_content(
+            self.mock_user_prompt, "test task guide", param1="value1", param2="value2"
+        )
+
+        assert result == "filled content"
+        expected_call_args = {
+            "task_guide": "test task guide",
+            "param1": "value1",
+            "param2": "value2",
+        }
+        self.mock_user_prompt.fill.assert_called_once_with(expected_call_args)
+
+    def test_build_user_content_with_list_task_guide(self):
+        """Test building user content with list task guide."""
+        task_guide = [
+            {"type": "image", "image_url": "test.jpg"},
+            {"type": "text", "text": "analyze this"},
+        ]
+
+        result = build_user_content(self.mock_user_prompt, task_guide, param1="value1")
+
+        assert isinstance(result, list)
+        assert len(result) == 3  # text + 2 task guide items
+        assert result[0]["type"] == "text"
+        assert result[0]["text"] == "filled content"
+        assert result[1] == {"type": "image", "image_url": "test.jpg"}
+        assert result[2] == {"type": "text", "text": "analyze this"}
+
+        # Verify the prompt was filled with the correct parameters
+        expected_call_args = {
+            "task_guide": "The task is to correctly answer the question with an image specified below.",
+            "param1": "value1",
+        }
+        self.mock_user_prompt.fill.assert_called_once_with(expected_call_args)
+
+    def test_build_user_content_with_invalid_task_guide_type(self):
+        """Test building user content with invalid task guide type."""
+        with pytest.raises(ValueError, match="task_guide should be str or list"):
+            build_user_content(
+                self.mock_user_prompt,
+                123,  # type: ignore # Invalid type for testing
+                param1="value1",
+            )
+
+    def test_build_user_content_string_task_guide_fill_error(self):
+        """Test building user content with string task guide when fill raises exception."""
+        self.mock_user_prompt.fill.side_effect = Exception("Missing placeholder")
+
+        with pytest.raises(
+            KeyError, match="Prompt template contains undefined placeholders"
+        ):
+            build_user_content(
+                self.mock_user_prompt, "test task guide", param1="value1"
+            )
+
+    def test_build_user_content_list_task_guide_fill_error(self):
+        """Test building user content with list task guide when fill raises exception."""
+        self.mock_user_prompt.fill.side_effect = Exception("Missing placeholder")
+        task_guide = [{"type": "text", "text": "test"}]
+
+        with pytest.raises(
+            KeyError, match="Prompt template contains undefined placeholders"
+        ):
+            build_user_content(self.mock_user_prompt, task_guide, param1="value1")
+
+    def test_build_user_content_no_additional_kwargs(self):
+        """Test building user content with only task guide, no additional kwargs."""
+        result = build_user_content(self.mock_user_prompt, "test task guide")
+
+        assert result == "filled content"
+        expected_call_args = {"task_guide": "test task guide"}
+        self.mock_user_prompt.fill.assert_called_once_with(expected_call_args)
+
+    def test_build_user_content_empty_list_task_guide(self):
+        """Test building user content with empty list task guide."""
+        result = build_user_content(self.mock_user_prompt, [], param1="value1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1  # Only text content
+        assert result[0]["type"] == "text"
+        assert result[0]["text"] == "filled content"

--- a/tests/agents/test_react.py
+++ b/tests/agents/test_react.py
@@ -1,0 +1,776 @@
+"""Comprehensive tests for the ReActAgent class."""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+from corral.agents.react import Action, ReActAgent, Thought
+from corral.agents.utils import LiteLLMMessage
+from corral.report import ToolResponse
+
+# Try to import pytest if available
+try:
+    import pytest
+
+    HAS_PYTEST = True
+except ImportError:
+    pytest = None
+    HAS_PYTEST = False
+
+try:
+    from promptstore import PromptStore
+except ImportError:
+    PromptStore = None
+
+
+class MockPrompt:
+    """Mock prompt class that implements the required fill method."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+    def fill(self, replacements: dict[str, Any]) -> str:
+        """Fill the prompt with replacements."""
+        result = self.content
+        for key, value in replacements.items():
+            result = result.replace(f"{{{{{key}}}}}", str(value))
+        return result
+
+
+class MockBenchmarkInterface:
+    """Mock BenchmarkInterface for testing."""
+
+    def __init__(self):
+        self.task_guide = "Test task guide"
+        self.tool_responses = []
+        self.tool_calls = []
+
+    def get_task_guide(self, task_id: str) -> str:
+        return self.task_guide
+
+    def execute_tool(
+        self, task_id: str, tool_name: str, arguments: dict
+    ) -> ToolResponse:
+        self.tool_calls.append(
+            {"task_id": task_id, "tool_name": tool_name, "arguments": arguments}
+        )
+        if self.tool_responses:
+            return self.tool_responses.pop(0)
+        return ToolResponse(success=True, result="Mock tool result", error=None)
+
+
+def create_mock_prompt_store():
+    """Create mock PromptStore for testing."""
+    if PromptStore is None:
+        return None
+    store = Mock(spec=PromptStore)
+    store.get.return_value = MockPrompt("Test prompt: {{task_guide}}")
+    return store
+
+
+def create_mock_interface():
+    """Create mock BenchmarkInterface for testing."""
+    return MockBenchmarkInterface()
+
+
+def create_react_agent():
+    """Create a ReActAgent instance for testing."""
+    return ReActAgent(model="test-model", max_iterations=3, temperature=0.5)
+
+
+# Conditionally set up pytest fixtures if available
+if HAS_PYTEST and pytest is not None:
+
+    @pytest.fixture
+    def mock_prompt_store():
+        """Mock PromptStore for testing."""
+        return create_mock_prompt_store()
+
+    @pytest.fixture
+    def mock_interface():
+        """Mock BenchmarkInterface for testing."""
+        return create_mock_interface()
+
+    @pytest.fixture
+    def react_agent():
+        """Create a ReActAgent instance for testing."""
+        return create_react_agent()
+else:
+    # Define regular functions for non-pytest usage
+    def mock_prompt_store():
+        return create_mock_prompt_store()
+
+    def mock_interface():
+        return create_mock_interface()
+
+    def react_agent():
+        return create_react_agent()
+
+
+class TestThought:
+    """Test cases for the Thought dataclass."""
+
+    def test_thought_creation(self):
+        """Test creating a Thought object."""
+        content = "I need to analyze the problem"
+        thought = Thought(content=content)
+        assert thought.content == content
+        assert isinstance(thought.content, str)
+
+    def test_thought_empty_content(self):
+        """Test creating a Thought with empty content."""
+        thought = Thought(content="")
+        assert thought.content == ""
+
+    def test_thought_multiline_content(self):
+        """Test creating a Thought with multiline content."""
+        content = "First line\nSecond line\nThird line"
+        thought = Thought(content=content)
+        assert thought.content == content
+        assert "\n" in thought.content
+
+
+class TestAction:
+    """Test cases for the Action dataclass."""
+
+    def test_action_creation(self):
+        """Test creating an Action object."""
+        tool_name = "test_tool"
+        arguments = {"param1": "value1", "param2": 42}
+        action = Action(tool_name=tool_name, arguments=arguments)
+
+        assert action.tool_name == tool_name
+        assert action.arguments == arguments
+        assert isinstance(action.arguments, dict)
+
+    def test_action_empty_arguments(self):
+        """Test creating an Action with empty arguments."""
+        action = Action(tool_name="test_tool", arguments={})
+        assert action.tool_name == "test_tool"
+        assert action.arguments == {}
+
+    def test_action_complex_arguments(self):
+        """Test creating an Action with complex arguments."""
+        arguments = {
+            "string_param": "test",
+            "int_param": 123,
+            "bool_param": True,
+            "list_param": [1, 2, 3],
+            "dict_param": {"nested": "value"},
+        }
+        action = Action(tool_name="complex_tool", arguments=arguments)
+        assert action.arguments == arguments
+
+
+class TestReActAgentInitialization:
+    """Test cases for ReActAgent initialization."""
+
+    def test_default_initialization(self):
+        """Test ReActAgent initialization with default parameters."""
+        agent = ReActAgent()
+
+        assert agent.model == "openai/gpt-4o"
+        assert agent.max_iterations == 10
+        assert agent.temperature == 0.7
+        assert agent.api_endpoint is None
+
+    def test_custom_initialization(self):
+        """Test ReActAgent initialization with custom parameters."""
+        agent = ReActAgent(
+            model="custom-model",
+            max_iterations=5,
+            temperature=0.3,
+            api_endpoint="http://custom-endpoint",
+        )
+
+        assert agent.model == "custom-model"
+        assert agent.max_iterations == 5
+        assert agent.temperature == 0.3
+        assert agent.api_endpoint == "http://custom-endpoint"
+
+    def test_initialization_with_custom_prompts(self):
+        """Test ReActAgent initialization with custom prompts."""
+        system_prompt = "Custom system prompt"
+        user_prompt = "Custom user prompt: {{task_guide}}"
+
+        agent = ReActAgent(system_prompt=system_prompt, user_prompt=user_prompt)
+
+        assert agent.system_prompt == system_prompt
+        assert agent.user_prompt == user_prompt
+
+    def test_initialization_with_prompt_store(self, mock_prompt_store):
+        """Test ReActAgent initialization with PromptStore."""
+        if PromptStore is None:
+            return  # Skip test if PromptStore not available
+        agent = ReActAgent(prompt_store=mock_prompt_store)
+        assert agent.store == mock_prompt_store
+
+    def test_initialization_with_kwargs(self):
+        """Test ReActAgent initialization with additional kwargs."""
+        agent = ReActAgent(
+            model="test-model", custom_param="custom_value", another_param=42
+        )
+
+        assert agent.model == "test-model"
+        # Additional kwargs should be passed to parent class
+
+
+class TestReActAgentParsing:
+    """Test cases for ReActAgent response parsing."""
+
+    def test_parse_llm_response_thought_only(self, react_agent):
+        """Test parsing response with only a thought."""
+        response = "Thought: I need to analyze this problem carefully."
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert thought.content == "I need to analyze this problem carefully."
+        assert actions is None
+
+    def test_parse_llm_response_thought_and_action(self, react_agent):
+        """Test parsing response with thought and action."""
+        response = """Thought: I need to search for information.
+Action: search
+Action Input: {"query": "test query", "limit": 10}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert thought.content == "I need to search for information."
+        assert actions is not None
+        assert len(actions) == 1
+        assert actions[0].tool_name == "search"
+        assert actions[0].arguments == {"query": "test query", "limit": 10}
+
+    def test_parse_llm_response_multiple_actions(self, react_agent):
+        """Test parsing response with multiple actions."""
+        response = """Thought: I need to use multiple tools.
+Action: search
+Action Input: {"query": "test"}
+Action: calculate
+Action Input: {"expression": "2+2"}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert actions is not None
+        assert len(actions) == 2
+        assert actions[0].tool_name == "search"
+        assert actions[0].arguments == {"query": "test"}
+        assert actions[1].tool_name == "calculate"
+        assert actions[1].arguments == {"expression": "2+2"}
+
+    def test_parse_llm_response_final_answer(self, react_agent):
+        """Test parsing response with final answer."""
+        response = """Thought: I have found the answer.
+Final Answer: The result is 42."""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert thought.content == "I have found the answer."
+        assert actions is None
+
+    def test_parse_llm_response_invalid_json(self, react_agent):
+        """Test parsing response with invalid JSON in action input."""
+        response = """Thought: Testing invalid JSON.
+Action: search
+Action Input: {invalid json}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert actions is None  # Should be None due to JSON parsing error
+
+    def test_parse_llm_response_no_thought(self, react_agent):
+        """Test parsing response with no thought."""
+        response = """Action: search
+Action Input: {"query": "test"}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is None
+        assert actions is not None
+        assert len(actions) == 1
+        assert actions[0].tool_name == "search"
+
+    def test_parse_llm_response_empty_response(self, react_agent):
+        """Test parsing empty response."""
+        response = ""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is None
+        assert actions is None
+
+    def test_parse_llm_response_multiline_thought(self, react_agent):
+        """Test parsing response with multiline thought."""
+        response = """Thought: This is a complex problem that requires
+multiple lines of reasoning to solve properly.
+Let me break it down step by step.
+Action: search
+Action Input: {"query": "complex problem"}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert (
+            "This is a complex problem that requires\nmultiple lines of reasoning"
+            in thought.content
+        )
+        assert actions is not None
+        assert len(actions) == 1
+
+
+class TestReActAgentRun:
+    """Test cases for ReActAgent.run method."""
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_final_answer(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method that returns final answer immediately."""
+        # Mock the LLM response
+        mock_response = Mock()
+        mock_response.content = "Thought: I can answer this directly.\nFinal Answer: 42"
+        mock_get_llm_response.return_value = mock_response
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert result == "42"
+        mock_create_prompt.assert_called_once()
+        mock_get_llm_response.assert_called_once()
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_tool_execution(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method that executes tools before finding answer."""
+        # Mock the LLM responses
+        response1 = Mock()
+        response1.content = """Thought: I need to search for information.
+Action: search
+Action Input: {"query": "test"}"""
+
+        response2 = Mock()
+        response2.content = (
+            "Thought: Based on the search results.\nFinal Answer: Found it!"
+        )
+
+        mock_get_llm_response.side_effect = [response1, response2]
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        # Set up tool response
+        mock_interface.tool_responses = [
+            ToolResponse(success=True, result="Search results", error=None)
+        ]
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert result == "Found it!"
+        assert len(mock_interface.tool_calls) == 1
+        assert mock_interface.tool_calls[0]["tool_name"] == "search"
+        assert mock_interface.tool_calls[0]["arguments"] == {"query": "test"}
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_tool_error(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method with tool execution error."""
+        # Mock the LLM responses
+        response1 = Mock()
+        response1.content = """Thought: I need to use a tool.
+Action: failing_tool
+Action Input: {"param": "value"}"""
+
+        response2 = Mock()
+        response2.content = "Thought: The tool failed.\nFinal Answer: Handled error"
+
+        mock_get_llm_response.side_effect = [response1, response2]
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        # Set up tool error response
+        mock_interface.tool_responses = [
+            ToolResponse(success=False, result=None, error="Tool failed")
+        ]
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert result == "Handled error"
+        assert len(mock_interface.tool_calls) == 1
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_max_iterations_exceeded(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method when max iterations is exceeded."""
+        # Mock the LLM response that never returns final answer
+        mock_response = Mock()
+        mock_response.content = """Thought: I'm thinking about this problem.
+Action: search
+Action Input: {"query": "test"}"""
+
+        mock_get_llm_response.return_value = mock_response
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        # Set up tool response
+        mock_interface.tool_responses = [
+            ToolResponse(success=True, result="Result", error=None)
+        ] * 10
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert (
+            result
+            == "Error solving the task: unable to complete it in the iteration limit"
+        )
+        assert (
+            len(mock_interface.tool_calls) == 3
+        )  # max_iterations is 3 for this test agent
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_multiple_tools_in_one_response(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method with multiple tools in one response."""
+        # Mock the LLM response
+        response1 = Mock()
+        response1.content = """Thought: I need to use multiple tools.
+Action: search
+Action Input: {"query": "test"}
+Action: calculate
+Action Input: {"expression": "2+2"}"""
+
+        response2 = Mock()
+        response2.content = "Thought: Got all results.\nFinal Answer: Complete"
+
+        mock_get_llm_response.side_effect = [response1, response2]
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        # Set up tool responses
+        mock_interface.tool_responses = [
+            ToolResponse(success=True, result="Search result", error=None),
+            ToolResponse(success=True, result="4", error=None),
+        ]
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert result == "Complete"
+        assert len(mock_interface.tool_calls) == 2
+        assert mock_interface.tool_calls[0]["tool_name"] == "search"
+        assert mock_interface.tool_calls[1]["tool_name"] == "calculate"
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_custom_task_prompt(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method with custom task prompt."""
+        # Mock the LLM response
+        mock_response = Mock()
+        mock_response.content = "Thought: Custom task.\nFinal Answer: Done"
+        mock_get_llm_response.return_value = mock_response
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        custom_task_prompt = "Custom task description"
+        result = react_agent.run(
+            mock_interface, "test_task_id", task_prompt=custom_task_prompt
+        )
+
+        assert result == "Done"
+
+        # Verify create_prompt was called with custom task prompt
+        call_args = mock_create_prompt.call_args
+        assert call_args[1]["task_guide"] == custom_task_prompt
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_history_and_examples(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method with history and examples."""
+        # Mock the LLM response
+        mock_response = Mock()
+        mock_response.content = (
+            "Thought: Using history and examples.\nFinal Answer: Success"
+        )
+        mock_get_llm_response.return_value = mock_response
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        history = [LiteLLMMessage(role="user", content="Previous message")]
+        examples = ["Example 1", "Example 2"]
+
+        result = react_agent.run(
+            mock_interface, "test_task_id", history=history, examples=examples
+        )
+
+        assert result == "Success"
+
+        # Verify create_prompt was called with history and examples
+        call_args = mock_create_prompt.call_args
+        assert call_args[1]["history"] == history
+        assert call_args[1]["examples"] == examples
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_message_construction(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test that messages are constructed correctly during run."""
+        # Mock the LLM responses
+        response1 = Mock()
+        response1.content = """Thought: I need to search.
+Action: search
+Action Input: {"query": "test"}"""
+
+        response2 = Mock()
+        response2.content = "Thought: Found it.\nFinal Answer: Result"
+
+        mock_get_llm_response.side_effect = [response1, response2]
+
+        # Mock create_prompt to return a list we can modify
+        initial_messages = [LiteLLMMessage(role="system", content="System prompt")]
+        mock_create_prompt.return_value = initial_messages
+
+        # Set up tool response
+        mock_interface.tool_responses = [
+            ToolResponse(success=True, result="Search result", error=None)
+        ]
+
+        # Check that messages were added correctly
+        assert (
+            len(react_agent.messages) >= 4
+        )  # Initial + assistant action + user observation + final answer
+
+        # Check message structure
+        messages = react_agent.messages
+        assert any(
+            msg.get("role") == "assistant"
+            and "Action: search" in msg.get("content", "")
+            for msg in messages
+        )
+        assert any(
+            msg.get("role") == "user"
+            and "Observation: Search result" in msg.get("content", "")
+            for msg in messages
+        )
+        assert any(
+            msg.get("role") == "assistant"
+            and "Final Answer: Result" in msg.get("content", "")
+            for msg in messages
+        )
+
+
+class TestReActAgentEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_parse_response_with_malformed_action(self, react_agent):
+        """Test parsing response with malformed action structure."""
+        response = """Thought: Testing malformed action.
+Action: search
+Action Input: not valid json at all"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert actions is None
+
+    def test_parse_response_with_nested_final_answer(self, react_agent):
+        """Test parsing response with nested final answer pattern."""
+        response = """Thought: The answer mentions "Final Answer: not really" in the text.
+Final Answer: The actual final answer is 42."""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert actions is None
+
+    def test_parse_response_with_special_characters(self, react_agent):
+        """Test parsing response with special characters in JSON."""
+        response = """Thought: Testing special characters.
+Action: search
+Action Input: {"query": "test with \\"quotes\\" and \\n newlines", "special": "chars: !@#$%^&*()"}"""
+
+        thought, actions = react_agent.parse_llm_response(response)
+
+        assert thought is not None
+        assert actions is not None
+        assert len(actions) == 1
+        assert actions[0].tool_name == "search"
+        assert "quotes" in actions[0].arguments["query"]
+        assert actions[0].arguments["special"] == "chars: !@#$%^&*()"
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_run_with_empty_llm_response(
+        self, mock_create_prompt, mock_get_llm_response, react_agent, mock_interface
+    ):
+        """Test run method with empty LLM response."""
+        # Mock empty LLM response
+        mock_response = Mock()
+        mock_response.content = ""
+        mock_get_llm_response.return_value = mock_response
+
+        # Mock create_prompt
+        mock_create_prompt.return_value = []
+
+        result = react_agent.run(mock_interface, "test_task_id")
+
+        assert (
+            result
+            == "Error solving the task: unable to complete it in the iteration limit"
+        )
+
+    def test_initialization_with_none_values(self):
+        """Test ReActAgent initialization with None values."""
+        agent = ReActAgent(
+            system_prompt=None,
+            user_prompt=None,
+            extractor_prompt=None,
+            api_endpoint=None,
+        )
+
+        # When system_prompt is None, it loads from prompt store with default ID
+        assert (
+            agent.system_prompt is not None
+        )  # It gets a default value from prompt store
+        assert (
+            agent.user_prompt is not None
+        )  # It gets a default value from prompt store
+        assert (
+            agent.extractor_prompt is not None
+        )  # It gets a default value from prompt store
+        assert agent.api_endpoint is None
+
+
+class TestReActAgentIntegration:
+    """Integration tests for ReActAgent with real-like scenarios."""
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_complete_react_cycle(
+        self, mock_create_prompt, mock_get_llm_response, mock_interface
+    ):
+        """Test a complete ReAct cycle with realistic interaction."""
+        agent = ReActAgent(model="test-model", max_iterations=5)
+
+        # Mock realistic LLM responses
+        responses = [
+            # First iteration - analyze problem
+            Mock(
+                content="""Thought: I need to understand the problem first.
+Action: analyze
+Action Input: {"text": "problem statement"}"""
+            ),
+            # Second iteration - search for information
+            Mock(
+                content="""Thought: Now I need to search for relevant information.
+Action: search
+Action Input: {"query": "relevant information", "limit": 5}"""
+            ),
+            # Third iteration - process results and provide answer
+            Mock(
+                content="""Thought: Based on the analysis and search results, I can now provide the answer.
+Final Answer: The solution is X because of Y and Z."""
+            ),
+        ]
+
+        mock_get_llm_response.side_effect = responses
+        mock_create_prompt.return_value = []
+
+        # Set up tool responses
+        mock_interface.tool_responses = [
+            ToolResponse(
+                success=True, result="Analysis complete: problem identified", error=None
+            ),
+            ToolResponse(
+                success=True, result="Search results: relevant data found", error=None
+            ),
+        ]
+
+        result = agent.run(mock_interface, "complex_task")
+
+        assert result == "The solution is X because of Y and Z."
+        assert len(mock_interface.tool_calls) == 2
+        assert mock_interface.tool_calls[0]["tool_name"] == "analyze"
+        assert mock_interface.tool_calls[1]["tool_name"] == "search"
+
+        # Verify message flow
+        assert (
+            len(agent.messages) >= 5
+        )  # 2 tool calls + 2 observations + final answer (create_prompt mocked to return empty list)
+
+    @patch("corral.agents.base_agent.BaseAgent.get_llm_response")
+    @patch("corral.agents.react.create_prompt")
+    def test_error_recovery_scenario(
+        self, mock_create_prompt, mock_get_llm_response, mock_interface
+    ):
+        """Test ReActAgent handling tool errors and recovery."""
+        agent = ReActAgent(model="test-model", max_iterations=5)
+
+        # Mock responses with error recovery
+        responses = [
+            # First iteration - try a tool that fails
+            Mock(
+                content="""Thought: I'll try using this tool.
+Action: failing_tool
+Action Input: {"param": "value"}"""
+            ),
+            # Second iteration - recover from error
+            Mock(
+                content="""Thought: The tool failed, let me try a different approach.
+Action: backup_tool
+Action Input: {"alternative": "approach"}"""
+            ),
+            # Third iteration - provide answer
+            Mock(
+                content="""Thought: This approach worked.
+Final Answer: Successfully recovered and found the answer."""
+            ),
+        ]
+
+        mock_get_llm_response.side_effect = responses
+        mock_create_prompt.return_value = []
+
+        # Set up tool responses - first fails, second succeeds
+        mock_interface.tool_responses = [
+            ToolResponse(
+                success=False, result=None, error="Tool failed with error message"
+            ),
+            ToolResponse(success=True, result="Backup approach successful", error=None),
+        ]
+
+        result = agent.run(mock_interface, "error_prone_task")
+
+        assert result == "Successfully recovered and found the answer."
+        assert len(mock_interface.tool_calls) == 2
+        assert mock_interface.tool_calls[0]["tool_name"] == "failing_tool"
+        assert mock_interface.tool_calls[1]["tool_name"] == "backup_tool"
+
+        # Check that error message was included in conversation
+        error_message_found = any(
+            msg.get("role") == "user"
+            and "Error: Tool failed with error message" in msg.get("content", "")
+            for msg in agent.messages
+        )
+        assert error_message_found

--- a/tests/agents/test_tool_calling_agent.py
+++ b/tests/agents/test_tool_calling_agent.py
@@ -1,0 +1,777 @@
+"""Tests for the ToolCallingAgent class."""
+
+import json
+from typing import Any
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from corral.agents.tool_calling import Action, ToolCallingAgent
+from corral.agents.utils import LiteLLMMessage
+from corral.evaluate import BenchmarkInterface
+from corral.report import ToolResponse
+
+
+def get_messages_by_role(messages, role):
+    """Helper function to get messages by role from TypedDict messages."""
+    result = []
+    for msg in messages:
+        if hasattr(msg, "get"):
+            # It's a dict/TypedDict
+            if msg.get("role") == role:
+                result.append(msg)
+        elif hasattr(msg, "role") and msg.role == role:
+            # It's an object with role attribute
+            result.append(msg)
+    return result
+
+
+class MockPrompt:
+    """Mock prompt class that implements the required fill method."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+    def fill(self, replacements: dict[str, Any]) -> str:
+        """Fill the prompt with replacements."""
+        result = self.content
+        for key, value in replacements.items():
+            result = result.replace(f"{{{{{key}}}}}", str(value))
+        return result
+
+
+class MockLLMResponse:
+    """Mock LLM response for testing."""
+
+    def __init__(self, content: str | None = None, tool_calls: list | None = None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+
+
+class MockToolCall:
+    """Mock tool call for testing."""
+
+    def __init__(self, call_id: str, name: str, arguments: dict):
+        self.id = call_id
+        self.function = Mock()
+        self.function.name = name
+        self.function.arguments = json.dumps(arguments)
+
+
+@pytest.fixture()
+def mock_prompt_store():
+    """Mock PromptStore for testing."""
+    store = Mock()
+    store.get.return_value = MockPrompt("System prompt")
+    return store
+
+
+@pytest.fixture()
+def mock_interface():
+    """Mock BenchmarkInterface for testing."""
+    interface = Mock(spec=BenchmarkInterface)
+    interface.get_available_tools_for_task.return_value = {
+        "tools": [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Test query"}
+                    },
+                    "required": ["query"],
+                },
+            }
+        ]
+    }
+    interface.get_task_prompt.return_value = "Test task prompt"
+
+    # Mock tool execution
+    mock_tool_response = Mock(spec=ToolResponse)
+    mock_tool_response.result = "Tool execution result"
+    mock_tool_response.error = None
+    interface.execute_tool.return_value = mock_tool_response
+
+    return interface
+
+
+@pytest.fixture()
+def tool_calling_agent():
+    """Create a ToolCallingAgent instance for testing."""
+    return ToolCallingAgent(
+        model="openai/gpt-4o",
+        max_iterations=5,
+        temperature=0.7,
+        system_prompt=MockPrompt("You are a helpful AI assistant."),
+        user_prompt=MockPrompt(
+            "Task: {{task_guide}}\n\nExamples: {{examples}}\n\nSolve this step by step."
+        ),
+    )
+
+
+class TestAction:
+    """Test the Action dataclass."""
+
+    def test_action_creation(self):
+        """Test Action dataclass creation."""
+        action = Action(tool_name="test_tool", arguments={"query": "test query"})
+
+        assert action.tool_name == "test_tool"
+        assert action.arguments == {"query": "test query"}
+
+    def test_action_with_complex_arguments(self):
+        """Test Action with complex arguments."""
+        complex_args = {
+            "string_arg": "test",
+            "number_arg": 42,
+            "list_arg": ["a", "b", "c"],
+            "dict_arg": {"nested": "value"},
+        }
+
+        action = Action(tool_name="complex_tool", arguments=complex_args)
+
+        assert action.tool_name == "complex_tool"
+        assert action.arguments == complex_args
+
+
+class TestToolCallingAgent:
+    """Test the ToolCallingAgent class."""
+
+    def test_init_with_defaults(self):
+        """Test ToolCallingAgent initialization with defaults."""
+        agent = ToolCallingAgent()
+
+        assert agent.model == "openai/gpt-4o"
+        assert agent.max_iterations == 10
+        assert agent.temperature == 0.7
+        assert agent.api_endpoint is None
+        assert agent._available_tools is None
+
+    def test_init_with_custom_params(self):
+        """Test ToolCallingAgent initialization with custom parameters."""
+        agent = ToolCallingAgent(
+            model="anthropic/claude-3-5-sonnet-20241022",
+            max_iterations=15,
+            temperature=0.3,
+            api_endpoint="https://custom.api.endpoint",
+        )
+
+        assert agent.model == "anthropic/claude-3-5-sonnet-20241022"
+        assert agent.max_iterations == 15
+        assert agent.temperature == 0.3
+        assert agent.api_endpoint == "https://custom.api.endpoint"
+
+    def test_init_with_prompt_store(self, mock_prompt_store):
+        """Test ToolCallingAgent initialization with PromptStore."""
+        agent = ToolCallingAgent(
+            prompt_store=mock_prompt_store,
+            system_prompt_id="test-system-id",
+            user_prompt_id="test-user-id",
+        )
+
+        # The prompt_store is stored as 'store' in BaseAgent
+        assert hasattr(agent, "store")
+        assert agent.store == mock_prompt_store
+
+    @patch("corral.agents.tool_calling.convert_to_openai_tool_format")
+    @patch("corral.agents.tool_calling.create_prompt")
+    def test_run_setup(
+        self, mock_create_prompt, mock_convert_tools, tool_calling_agent, mock_interface
+    ):
+        """Test that run method sets up correctly."""
+        # Mock the prompt creation
+        mock_create_prompt.return_value = [
+            LiteLLMMessage(role="system", content="System prompt"),
+            LiteLLMMessage(role="user", content="User prompt"),
+        ]
+
+        # Mock tool conversion
+        mock_convert_tools.return_value = [
+            {"type": "function", "function": {"name": "test_tool"}}
+        ]
+
+        # Mock get_llm_response to return final answer immediately
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: Test result"
+            )
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            # Verify setup calls
+            mock_interface.get_available_tools_for_task.assert_called_once_with(
+                "test_task"
+            )
+            mock_interface.get_task_prompt.assert_called_once_with("test_task")
+            mock_convert_tools.assert_called_once()
+            mock_create_prompt.assert_called_once()
+
+            # Verify tools are stored
+            assert tool_calling_agent._available_tools == [
+                {"type": "function", "function": {"name": "test_tool"}}
+            ]
+
+            assert result == "Test result"
+
+    def test_run_with_final_answer(self, tool_calling_agent, mock_interface):
+        """Test run method when LLM returns final answer immediately."""
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: Direct answer"
+            )
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Direct answer"
+            assert len(tool_calling_agent.messages) == 3  # system + user + assistant
+            assert tool_calling_agent.messages[-1]["role"] == "assistant"
+            assert (
+                tool_calling_agent.messages[-1]["content"]
+                == "Final Answer: Direct answer"
+            )
+
+    def test_run_with_tool_calls(self, tool_calling_agent, mock_interface):
+        """Test run method with tool calls."""
+        # First response: tool call
+        tool_call = MockToolCall("call_1", "test_tool", {"query": "test"})
+        first_response = MockLLMResponse(content=None, tool_calls=[tool_call])
+
+        # Second response: final answer
+        second_response = MockLLMResponse(content="Final Answer: Tool result processed")
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Tool result processed"
+
+            # Verify tool execution
+            mock_interface.execute_tool.assert_called_once_with(
+                "test_task", "test_tool", {"query": "test"}
+            )
+
+            # Verify message flow
+            assert (
+                len(tool_calling_agent.messages) >= 4
+            )  # system + user + assistant + tool + assistant
+
+            # Check tool message was added
+            tool_messages = get_messages_by_role(tool_calling_agent.messages, "tool")
+            assert len(tool_messages) == 1
+            assert tool_messages[0]["tool_call_id"] == "call_1"
+            assert tool_messages[0]["content"] == "Tool execution result"
+            assert tool_messages[0]["name"] == "test_tool"
+
+    def test_run_with_multiple_tool_calls(self, tool_calling_agent, mock_interface):
+        """Test run method with multiple tool calls in one response."""
+        tool_call_1 = MockToolCall("call_1", "test_tool", {"query": "first"})
+        tool_call_2 = MockToolCall("call_2", "test_tool", {"query": "second"})
+
+        first_response = MockLLMResponse(
+            content=None, tool_calls=[tool_call_1, tool_call_2]
+        )
+        second_response = MockLLMResponse(
+            content="Final Answer: Multiple tools processed"
+        )
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Multiple tools processed"
+
+            # Verify both tools were executed
+            assert mock_interface.execute_tool.call_count == 2
+            mock_interface.execute_tool.assert_has_calls(
+                [
+                    call("test_task", "test_tool", {"query": "first"}),
+                    call("test_task", "test_tool", {"query": "second"}),
+                ]
+            )
+
+            # Verify two tool messages were added
+            tool_messages = get_messages_by_role(tool_calling_agent.messages, "tool")
+            assert len(tool_messages) == 2
+
+    def test_run_with_tool_error(self, tool_calling_agent, mock_interface):
+        """Test run method when tool execution fails."""
+        # Mock tool execution failure
+        mock_tool_response = Mock(spec=ToolResponse)
+        mock_tool_response.result = None
+        mock_tool_response.error = "Tool execution failed"
+        mock_interface.execute_tool.return_value = mock_tool_response
+
+        tool_call = MockToolCall("call_1", "test_tool", {"query": "test"})
+        first_response = MockLLMResponse(content=None, tool_calls=[tool_call])
+        second_response = MockLLMResponse(content="Final Answer: Handled error")
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Handled error"
+
+            # Verify error was handled - the code converts str(None) to "None"
+            tool_messages = get_messages_by_role(tool_calling_agent.messages, "tool")
+            assert len(tool_messages) == 1
+            assert tool_messages[0]["content"] == "None"  # str(None) = "None"
+
+    def test_run_with_tool_exception(self, tool_calling_agent, mock_interface):
+        """Test run method when tool execution raises exception."""
+        # Mock tool execution to raise exception
+        mock_interface.execute_tool.side_effect = Exception("Unexpected error")
+
+        tool_call = MockToolCall("call_1", "test_tool", {"query": "test"})
+        first_response = MockLLMResponse(content=None, tool_calls=[tool_call])
+        second_response = MockLLMResponse(content="Final Answer: Exception handled")
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Exception handled"
+
+            # Verify exception was handled
+            tool_messages = get_messages_by_role(tool_calling_agent.messages, "tool")
+            assert len(tool_messages) == 1
+            assert tool_messages[0]["content"] == "Unexpected error"
+
+    def test_run_with_llm_response_exception(self, tool_calling_agent, mock_interface):
+        """Test run method when LLM response raises exception."""
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [
+                Exception("LLM error"),
+                MockLLMResponse(content="Final Answer: Recovered from error"),
+            ]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Recovered from error"
+
+            # Verify error message was added
+            error_messages = get_messages_by_role(tool_calling_agent.messages, "system")
+            assert len(error_messages) == 2  # initial system + error system
+            assert (
+                "Error during agent iteration: LLM error"
+                in error_messages[1]["content"]
+            )
+
+    def test_run_with_content_but_no_final_answer(
+        self, tool_calling_agent, mock_interface
+    ):
+        """Test run method when LLM returns content but no final answer."""
+        first_response = MockLLMResponse(content="I need to think about this...")
+        second_response = MockLLMResponse(content="Final Answer: Now I have the answer")
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Now I have the answer"
+
+            # Verify intermediate response was added
+            assistant_messages = get_messages_by_role(
+                tool_calling_agent.messages, "assistant"
+            )
+            assert len(assistant_messages) == 2
+            assert assistant_messages[0]["content"] == "I need to think about this..."
+
+    def test_run_max_iterations_reached(self, tool_calling_agent, mock_interface):
+        """Test run method when max iterations is reached."""
+        # Set low max iterations for testing
+        tool_calling_agent.max_iterations = 2
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Still thinking..."
+            )
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "Error solving the task. Maximum iterations reached."
+
+            # Verify max iterations was reached
+            assert mock_llm_response.call_count == 2
+
+            # Verify error message was added
+            error_messages = [
+                msg
+                for msg in tool_calling_agent.messages
+                if msg.get("role") == "assistant"
+                and msg.get("name") == "tool-calling-error"
+            ]
+            assert len(error_messages) == 1
+            assert "Maximum iterations reached" in error_messages[0]["content"]
+
+    def test_run_with_custom_task_prompt(self, tool_calling_agent, mock_interface):
+        """Test run method with custom task prompt."""
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: Custom task result"
+            )
+
+            result = tool_calling_agent.run(
+                mock_interface, "test_task", task_prompt="Custom task prompt"
+            )
+
+            assert result == "Custom task result"
+
+            # Verify custom task prompt was used instead of interface prompt
+            mock_interface.get_task_prompt.assert_not_called()
+
+    def test_run_with_history(self, tool_calling_agent, mock_interface):
+        """Test run method with conversation history."""
+        history = [
+            LiteLLMMessage(role="user", content="Previous question"),
+            LiteLLMMessage(role="assistant", content="Previous answer"),
+        ]
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: With history"
+            )
+
+            result = tool_calling_agent.run(
+                mock_interface, "test_task", history=history
+            )
+
+            assert result == "With history"
+
+            # Verify history was included in messages
+            # Should have system + user + history + user (task) + assistant
+            assert len(tool_calling_agent.messages) >= 4
+
+    def test_run_with_examples(self, tool_calling_agent, mock_interface):
+        """Test run method with examples."""
+        examples = ["Example 1", "Example 2"]
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: With examples"
+            )
+
+            result = tool_calling_agent.run(
+                mock_interface, "test_task", examples=examples
+            )
+
+            assert result == "With examples"
+
+    def test_run_case_insensitive_final_answer(
+        self, tool_calling_agent, mock_interface
+    ):
+        """Test that final answer matching is case insensitive."""
+        test_cases = [
+            "final answer: lowercase",
+            "Final Answer: normal case",
+            "FINAL ANSWER: uppercase",
+            "Final answer: mixed case",
+        ]
+
+        for content in test_cases:
+            with patch.object(
+                tool_calling_agent, "get_llm_response"
+            ) as mock_llm_response:
+                mock_llm_response.return_value = MockLLMResponse(content=content)
+
+                result = tool_calling_agent.run(mock_interface, "test_task")
+
+                expected = content.split(":", 1)[1].strip()
+                assert result == expected
+
+    def test_run_final_answer_extraction(self, tool_calling_agent, mock_interface):
+        """Test final answer extraction from complex content."""
+        content = """
+        I need to solve this step by step.
+
+        First, let me analyze the problem...
+
+        After careful consideration, I believe the answer is:
+
+        Final Answer: The solution is 42 with detailed explanation.
+        """
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(content=content)
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "The solution is 42 with detailed explanation."
+
+    @patch("corral.agents.tool_calling.convert_to_openai_tool_format")
+    def test_tools_conversion_called_correctly(
+        self, mock_convert_tools, tool_calling_agent, mock_interface
+    ):
+        """Test that tools are converted to OpenAI format correctly."""
+        expected_tools = [{"type": "function", "function": {"name": "test_tool"}}]
+        mock_convert_tools.return_value = expected_tools
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: Test"
+            )
+
+            tool_calling_agent.run(mock_interface, "test_task")
+
+            # Verify convert_to_openai_tool_format was called with correct tools
+            mock_convert_tools.assert_called_once()
+            args, kwargs = mock_convert_tools.call_args
+            assert len(args) == 1
+            # The mock_interface now returns a dict with tools key
+            expected_arg = mock_interface.get_available_tools_for_task.return_value
+            assert args[0] == expected_arg
+
+    def test_available_tools_storage(self, tool_calling_agent, mock_interface):
+        """Test that available tools are stored correctly."""
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.return_value = MockLLMResponse(
+                content="Final Answer: Test"
+            )
+
+            # Initially no tools
+            assert tool_calling_agent._available_tools is None
+
+            tool_calling_agent.run(mock_interface, "test_task")
+
+            # Tools should be stored after run
+            assert tool_calling_agent._available_tools is not None
+            assert isinstance(tool_calling_agent._available_tools, list)
+
+    def test_json_parsing_in_tool_calls(self, tool_calling_agent, mock_interface):
+        """Test that JSON parsing works correctly for tool arguments."""
+        complex_args = {
+            "string_param": "test string",
+            "number_param": 42,
+            "boolean_param": True,
+            "array_param": [1, 2, 3],
+            "object_param": {"nested": "value"},
+        }
+
+        tool_call = MockToolCall("call_1", "test_tool", complex_args)
+        first_response = MockLLMResponse(content=None, tool_calls=[tool_call])
+        second_response = MockLLMResponse(content="Final Answer: JSON parsed correctly")
+
+        with patch.object(tool_calling_agent, "get_llm_response") as mock_llm_response:
+            mock_llm_response.side_effect = [first_response, second_response]
+
+            result = tool_calling_agent.run(mock_interface, "test_task")
+
+            assert result == "JSON parsed correctly"
+
+            # Verify JSON was parsed correctly
+            mock_interface.execute_tool.assert_called_once_with(
+                "test_task", "test_tool", complex_args
+            )
+
+    def test_docstring_requirements(self):
+        """Test that the class docstring mentions required prompt fields."""
+        docstring = ToolCallingAgent.__doc__
+
+        # Check that docstring exists and contains required fields
+        assert docstring is not None
+        assert "{{task_guide}}" in docstring
+        assert "{{examples}}" in docstring
+        assert "Required Prompt Fields" in docstring
+
+        # Check that it mentions function calling
+        assert "function calling" in docstring or "tool calling" in docstring
+
+    def test_inheritance_from_base_agent(self):
+        """Test that ToolCallingAgent inherits from BaseAgent."""
+        from corral.agents.base_agent import BaseAgent
+
+        assert issubclass(ToolCallingAgent, BaseAgent)
+
+        # Test that it has the required abstract method
+        agent = ToolCallingAgent()
+        assert hasattr(agent, "run")
+        assert callable(agent.run)
+
+
+class TestToolCallingAgentDefaultPrompts:
+    """Test that the default prompts contain the expected information."""
+
+    def test_default_system_prompt_content(self):
+        """Test that the default system prompt contains expected content."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the system prompt using the default ID
+            system_prompt = store.get("400fcecf-f5f2-464b-aff5-8a4377c9685c")
+
+            # Check that it contains expected content
+            content = system_prompt.content
+            assert "autonomous agent" in content.lower()
+            assert "environment" in content.lower()
+
+    def test_default_user_prompt_content(self):
+        """Test that the default user prompt contains expected placeholders and instructions."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the user prompt using the default ID
+            user_prompt = store.get("fe04453b-5469-4611-bba6-6d81487df787")
+
+            # Check that it contains expected content
+            content = user_prompt.content
+            assert "{{task_guide}}" in content
+            assert "Final Answer:" in content
+            assert "tools available" in content.lower()
+            assert "task is completed" in content.lower()
+
+    def test_default_extractor_prompt_content(self):
+        """Test that the default extractor prompt contains expected placeholders."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the extractor prompt using the default ID
+            extractor_prompt = store.get("9d37e4a0-26c5-438a-ba1b-a273388fcded")
+
+            # Check that it contains expected content
+            content = extractor_prompt.content
+            assert "{{message}}" in content
+            assert "{{answer}}" in content
+            assert "extract" in content.lower()
+            assert "answer only" in content.lower()
+
+    def test_user_prompt_template_variables(self):
+        """Test that the user prompt template supports required variables."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the user prompt using the default ID
+            user_prompt = store.get("fe04453b-5469-4611-bba6-6d81487df787")
+
+            # Test that it can be filled with required variables
+            filled_content = user_prompt.fill(
+                {"task_guide": "Test task description", "examples": "Test examples"}
+            )
+
+            # Check that variables were replaced
+            assert "Test task description" in filled_content
+            assert "{{task_guide}}" not in filled_content
+
+            # Check that the structure is maintained
+            assert "Final Answer:" in filled_content
+            assert "tools available" in filled_content.lower()
+
+    def test_extractor_prompt_template_variables(self):
+        """Test that the extractor prompt template supports required variables."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the extractor prompt using the default ID
+            extractor_prompt = store.get("9d37e4a0-26c5-438a-ba1b-a273388fcded")
+
+            # Test that it can be filled with required variables
+            filled_content = extractor_prompt.fill(
+                {"message": "Test message content", "answer": "Test answer content"}
+            )
+
+            # Check that variables were replaced
+            assert "Test message content" in filled_content
+            assert "Test answer content" in filled_content
+            assert "{{message}}" not in filled_content
+            assert "{{answer}}" not in filled_content
+
+    def test_default_prompt_ids_match_class_defaults(self):
+        """Test that the default prompt IDs in the class match the available prompts."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Check that all default prompt IDs exist in the store
+            system_prompt_id = "400fcecf-f5f2-464b-aff5-8a4377c9685c"
+            user_prompt_id = "fe04453b-5469-4611-bba6-6d81487df787"
+            extractor_prompt_id = "9d37e4a0-26c5-438a-ba1b-a273388fcded"
+
+            # These should not raise exceptions
+            system_prompt = store.get(system_prompt_id)
+            user_prompt = store.get(user_prompt_id)
+            extractor_prompt = store.get(extractor_prompt_id)
+
+            # Check that they have the expected interface
+            assert hasattr(system_prompt, "content")
+            assert hasattr(user_prompt, "fill")
+            assert hasattr(extractor_prompt, "fill")
+
+    def test_user_prompt_does_not_contain_tool_descriptions(self):
+        """Test that the user prompt does not contain tool descriptions (as per docstring)."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the user prompt using the default ID
+            user_prompt = store.get("fe04453b-5469-4611-bba6-6d81487df787")
+
+            # Check that it doesn't contain tool descriptions
+            content = user_prompt.content.lower()
+
+            # Should not contain explicit tool descriptions or tool lists
+            assert "available tools:" not in content
+            assert "tool descriptions:" not in content
+            assert "{{tools}}" not in content
+
+            # But should mention tools generically
+            assert "tools available" in content or "use some of the tools" in content
+
+    def test_user_prompt_missing_examples_variable(self):
+        """Test that the user prompt handles missing examples variable gracefully."""
+        import importlib.resources
+
+        from promptstore import PromptStore
+
+        # Get the actual prompt store path
+        with importlib.resources.path("corral.agents", "prompts") as prompts_path:
+            store = PromptStore(prompts_path)
+
+            # Get the user prompt using the default ID
+            user_prompt = store.get("fe04453b-5469-4611-bba6-6d81487df787")
+
+            # Fill with only task_guide, leaving examples empty
+            filled_content = user_prompt.fill({"task_guide": "Test task description"})
+
+            # Should still contain the task description
+            assert "Test task description" in filled_content
+            assert "Final Answer:" in filled_content
+
+            # The {{examples}} placeholder should remain (or be empty depending on implementation)
+            # This tests that the prompt doesn't break when examples is not provided

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -1,0 +1,661 @@
+import json
+import tempfile
+from pathlib import Path
+from typing import cast
+from unittest.mock import Mock, patch
+
+import pytest
+
+from corral.agents.utils import (
+    RETRY_EXCEPTIONS,
+    TYPE_MAPPING,
+    LiteLLMMessage,
+    _parse_argument_string_to_dict,
+    before_sleep_loguru,
+    convert_dict_arg,
+    convert_to_openai_tool_format,
+    format_examples,
+    llm_call,
+    parse_string_argument,
+    save_agent_messages,
+    serialize_messages,
+)
+
+
+def test_type_mapping_completeness():
+    """Test that TYPE_MAPPING contains expected type mappings."""
+    expected_mappings = {
+        "str": "string",
+        "bool": "boolean",
+        "int": "integer",
+        "float": "number",
+        "list[str]": "array",
+        "none": "null",
+        "dict": "object",
+    }
+    assert expected_mappings == TYPE_MAPPING
+
+
+def test_retry_exceptions_tuple():
+    """Test that RETRY_EXCEPTIONS contains expected exception types."""
+    try:
+        import openai
+
+        expected_exceptions = (
+            openai.APITimeoutError,
+            openai.APIConnectionError,
+            openai.APIError,
+            openai.APIStatusError,
+            openai.InternalServerError,
+        )
+        assert expected_exceptions == RETRY_EXCEPTIONS
+    except ImportError:
+        # Skip test if openai not available
+        pass
+
+
+@patch("corral.agents.utils.logger")
+def test_before_sleep_loguru_logs_retry_info(mock_logger):
+    """Test that before_sleep_loguru logs retry information."""
+    mock_retry_state = Mock()
+    mock_retry_state.attempt_number = 2
+    mock_retry_state.next_action.sleep = 30.0
+
+    before_sleep_loguru(mock_retry_state)
+
+    mock_logger.info.assert_called_once_with("Retrying: 2, wait: 30.0 seconds")
+
+
+def test_litellm_message_structure():
+    """Test that LiteLLMMessage has expected structure."""
+    # Test with minimal required fields
+    msg1: LiteLLMMessage = {"role": "user", "content": "Hello"}
+    assert msg1["role"] == "user"
+    assert msg1["content"] == "Hello"
+
+    # Test with optional fields
+    msg2: LiteLLMMessage = {
+        "role": "assistant",
+        "content": "Hi there",
+        "tool_call_id": "call_123",
+        "name": "assistant",
+    }
+    assert msg2["tool_call_id"] == "call_123"
+    assert msg2["name"] == "assistant"
+
+
+@patch("corral.agents.utils.litellm")
+def test_llm_call_basic(mock_litellm):
+    """Test basic llm_call without tools."""
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_litellm.completion.return_value = mock_response
+
+    messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+    result = llm_call(model="gpt-3.5-turbo", messages=messages, temperature=0.7)
+
+    assert result == mock_message
+    mock_litellm.completion.assert_called_once()
+    call_args = mock_litellm.completion.call_args[1]
+    assert call_args["model"] == "gpt-3.5-turbo"
+    assert call_args["messages"] == messages
+    assert call_args["temperature"] == 0.7
+    assert call_args["api_base"] is None
+
+
+@patch("corral.agents.utils.litellm")
+def test_llm_call_with_tools(mock_litellm):
+    """Test llm_call with tools."""
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_litellm.completion.return_value = mock_response
+
+    messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+    tools = [{"type": "function", "function": {"name": "test_tool"}}]
+
+    result = llm_call(
+        model="gpt-3.5-turbo", messages=messages, temperature=0.7, tools=tools
+    )
+
+    assert result == mock_message
+    call_args = mock_litellm.completion.call_args[1]
+    assert call_args["tools"] == tools
+    assert call_args["tool_choice"] == "auto"
+
+
+@patch("corral.agents.utils.litellm")
+def test_llm_call_anthropic_model(mock_litellm):
+    """Test llm_call with anthropic model adds max_tokens."""
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_litellm.completion.return_value = mock_response
+
+    messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+    result = llm_call(
+        model="anthropic/claude-3-sonnet", messages=messages, temperature=0.7
+    )
+
+    assert result == mock_message
+    call_args = mock_litellm.completion.call_args[1]
+    assert call_args["max_tokens"] == 8192
+
+
+@patch("corral.agents.utils.litellm")
+def test_llm_call_with_usage_info(mock_litellm):
+    """Test llm_call with return_usage=True."""
+    mock_response = Mock()
+    mock_message = Mock()
+    mock_usage = Mock()
+    mock_usage.prompt_tokens = 10
+    mock_usage.completion_tokens = 20
+    mock_usage.total_tokens = 30
+    mock_response.choices = [Mock(message=mock_message)]
+    mock_response.usage = mock_usage
+    mock_litellm.completion.return_value = mock_response
+
+    messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+    result = llm_call(
+        model="gpt-3.5-turbo", messages=messages, temperature=0.7, return_usage=True
+    )
+
+    assert isinstance(result, tuple)
+    message, usage_info = result
+    assert message == mock_message
+    assert usage_info == {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+@patch("corral.agents.utils.litellm")
+def test_llm_call_exception_handling(mock_litellm):
+    """Test llm_call exception handling."""
+    mock_litellm.completion.side_effect = Exception("API Error")
+
+    messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+    with pytest.raises(Exception) as exc_info:
+        llm_call(model="gpt-3.5-turbo", messages=messages, temperature=0.7)
+
+    assert str(exc_info.value) == "API Error"
+
+
+def test_format_examples_none():
+    """Test format_examples with None input."""
+    result = format_examples(None)
+    assert result == ""
+
+
+def test_format_examples_empty_list():
+    """Test format_examples with empty list."""
+    result = format_examples([])
+    assert (
+        result
+        == "To help you in understanding this task, the next 0 examples are provided:\n\n"
+    )
+
+
+def test_format_examples_single_example():
+    """Test format_examples with single example."""
+    examples = ["This is an example."]
+    result = format_examples(examples)
+    expected = "To help you in understanding this task, the next 1 examples are provided:\n\nThis is an example."
+    assert result == expected
+
+
+def test_format_examples_multiple_examples():
+    """Test format_examples with multiple examples."""
+    examples = ["Example 1", "Example 2", "Example 3"]
+    result = format_examples(examples)
+    expected = "To help you in understanding this task, the next 3 examples are provided:\n\nExample 1\n\nExample 2\n\nExample 3"
+    assert result == expected
+
+
+def test_convert_dict_arg_basic_string():
+    """Test convert_dict_arg with basic string argument."""
+    arg = {"name": "test_arg", "type": "str", "description": "A test argument"}
+    result = convert_dict_arg(arg)
+    expected = {"description": "A test argument", "type": "string"}
+    assert result == expected
+
+
+def test_convert_dict_arg_list_str():
+    """Test convert_dict_arg with list[str] type."""
+    arg = {"name": "items", "type": "list[str]", "description": "A list of items"}
+    result = convert_dict_arg(arg)
+    expected = {
+        "description": 'A list of items - Provide as an array of strings, e.g., ["item1", "item2"]',
+        "type": "array",
+        "items": {"type": "string"},
+    }
+    assert result == expected
+
+
+def test_convert_dict_arg_with_choices():
+    """Test convert_dict_arg with choices."""
+    arg = {
+        "name": "operation",
+        "type": "str",
+        "description": "Math operation",
+        "choices": ["add", "subtract", "multiply"],
+    }
+    result = convert_dict_arg(arg)
+    expected = {
+        "description": "Math operation",
+        "type": "string",
+        "enum": ["add", "subtract", "multiply"],
+    }
+    assert result == expected
+
+
+def test_convert_dict_arg_with_default():
+    """Test convert_dict_arg with default value."""
+    arg = {
+        "name": "count",
+        "type": "int",
+        "description": "Number of items",
+        "default": 5,
+    }
+    result = convert_dict_arg(arg)
+    expected = {"description": "Number of items", "type": "integer", "default": 5}
+    assert result == expected
+
+
+@patch("corral.agents.utils.logger")
+def test_convert_dict_arg_unknown_type(mock_logger):
+    """Test convert_dict_arg with unknown type."""
+    arg = {
+        "name": "unknown",
+        "type": "unknown_type",
+        "description": "Unknown type argument",
+    }
+    result = convert_dict_arg(arg)
+    expected = {"description": "Unknown type argument", "type": "string"}
+    assert result == expected
+    mock_logger.warning.assert_called_once()
+
+
+def test_convert_dict_arg_not_dict():
+    """Test convert_dict_arg with non-dict input."""
+    with pytest.raises(TypeError) as exc_info:
+        convert_dict_arg(cast(dict, "not a dict"))
+
+    assert "Expected argument specification to be a dictionary" in str(exc_info.value)
+
+
+def test_convert_dict_arg_missing_type():
+    """Test convert_dict_arg with missing type."""
+    arg = {"name": "test", "description": "Test argument"}
+    with pytest.raises(ValueError) as exc_info:
+        convert_dict_arg(arg)
+
+    assert "Argument 'type' is missing" in str(exc_info.value)
+
+
+def test_parse_argument_string_required():
+    """Test parsing required argument string."""
+    arg_string = "name (str, required): The name of the item"
+    result = _parse_argument_string_to_dict(arg_string)
+    expected = {
+        "name": "name",
+        "type": "str",
+        "required": True,
+        "description": "The name of the item",
+    }
+    assert result == expected
+
+
+def test_parse_argument_string_optional():
+    """Test parsing optional argument string."""
+    arg_string = "count (int, optional): Number of items"
+    result = _parse_argument_string_to_dict(arg_string)
+    expected = {
+        "name": "count",
+        "type": "int",
+        "required": False,
+        "description": "Number of items",
+    }
+    assert result == expected
+
+
+def test_parse_argument_string_with_default():
+    """Test parsing argument string with default value."""
+    arg_string = "timeout (float, optional, default: 30.0): Timeout in seconds"
+    result = _parse_argument_string_to_dict(arg_string)
+    expected = {
+        "name": "timeout",
+        "type": "float",
+        "required": False,
+        "description": "Timeout in seconds",
+        "default": "30.0",
+    }
+    assert result == expected
+
+
+@patch("corral.agents.utils.logger")
+def test_parse_argument_string_invalid_format(mock_logger):
+    """Test parsing invalid argument string format."""
+    arg_string = "invalid format"
+    result = _parse_argument_string_to_dict(arg_string)
+    assert result is None
+    mock_logger.warning.assert_called_once()
+
+
+def test_convert_to_openai_tool_format_basic():
+    """Test basic tool conversion."""
+    tools_dict = {
+        "tools": [
+            {
+                "name": "calculator",
+                "description": "Perform basic math operations",
+                "arguments": [
+                    {
+                        "name": "operation",
+                        "type": "str",
+                        "description": "Math operation",
+                        "required": True,
+                    },
+                    {
+                        "name": "x",
+                        "type": "float",
+                        "description": "First number",
+                        "required": True,
+                    },
+                ],
+            }
+        ]
+    }
+
+    result = convert_to_openai_tool_format(tools_dict)
+
+    assert len(result) == 1
+    tool = result[0]
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "calculator"
+    assert tool["function"]["description"] == "Perform basic math operations"
+    assert "operation" in tool["function"]["parameters"]["properties"]
+    assert "x" in tool["function"]["parameters"]["properties"]
+    assert tool["function"]["parameters"]["required"] == ["operation", "x"]
+
+
+def test_convert_to_openai_tool_format_string_arguments():
+    """Test tool conversion with string arguments."""
+    tools_dict = {
+        "tools": [
+            {
+                "name": "test_tool",
+                "description": "A test tool",
+                "arguments": [
+                    "name (str, required): The name",
+                    "count (int, optional): Number of items",
+                ],
+            }
+        ]
+    }
+
+    result = convert_to_openai_tool_format(tools_dict)
+
+    assert len(result) == 1
+    tool = result[0]
+    assert tool["function"]["name"] == "test_tool"
+    assert "name" in tool["function"]["parameters"]["properties"]
+    assert "count" in tool["function"]["parameters"]["properties"]
+    assert tool["function"]["parameters"]["required"] == ["name"]
+
+
+@patch("corral.agents.utils.logger")
+def test_convert_to_openai_tool_format_no_tools(mock_logger):
+    """Test tool conversion with no tools."""
+    tools_dict = {}
+
+    result = convert_to_openai_tool_format(tools_dict)
+    assert result == []
+    mock_logger.warning.assert_called_once()
+
+
+@patch("corral.agents.utils.logger")
+def test_convert_to_openai_tool_format_malformed_tool(mock_logger):
+    """Test tool conversion with malformed tool."""
+    tools_dict = {
+        "tools": [{"name": "incomplete_tool", "description": "Missing arguments"}]
+    }
+
+    result = convert_to_openai_tool_format(tools_dict)
+    assert result == []
+    mock_logger.warning.assert_called_once()
+
+
+def test_parse_string_argument_required():
+    """Test parsing required string argument."""
+    arg_string = "path (str, required): Path to the directory"
+    result = parse_string_argument(arg_string)
+    expected = {
+        "name": "path",
+        "type": "str",
+        "description": "Path to the directory",
+        "required": True,
+    }
+    assert result == expected
+
+
+def test_parse_string_argument_optional():
+    """Test parsing optional string argument."""
+    arg_string = "timeout (int, optional): Timeout value"
+    result = parse_string_argument(arg_string)
+    expected = {
+        "name": "timeout",
+        "type": "int",
+        "description": "Timeout value",
+        "required": False,
+    }
+    assert result == expected
+
+
+def test_parse_string_argument_invalid_format():
+    """Test parsing invalid string argument format."""
+    arg_string = "invalid format"
+    result = parse_string_argument(arg_string)
+    assert result is None
+
+
+def test_serialize_messages_dict_messages():
+    """Test serializing dictionary messages."""
+    messages = cast(
+        list[LiteLLMMessage],
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ],
+    )
+
+    result = serialize_messages(messages)
+
+    assert result == messages
+
+
+def test_serialize_messages_with_tool_calls():
+    """Test serializing messages with tool calls."""
+    mock_tool_call = Mock()
+    mock_tool_call.id = "call_123"
+    mock_tool_call.function.name = "test_function"
+    mock_tool_call.function.arguments = '{"arg": "value"}'
+
+    mock_message = Mock()
+    mock_message.role = "assistant"
+    mock_message.content = "I'll help you"
+    mock_message.tool_calls = [mock_tool_call]
+    mock_message.tool_call_id = None
+    mock_message.name = None
+
+    result = serialize_messages([mock_message])
+
+    assert len(result) == 1
+    message = result[0]
+    assert message["role"] == "assistant"
+    assert message["content"] == "I'll help you"
+    assert len(message["tool_calls"]) == 1
+    assert message["tool_calls"][0]["id"] == "call_123"
+    assert message["tool_calls"][0]["function"]["name"] == "test_function"
+    assert message["tool_calls"][0]["function"]["arguments"] == '{"arg": "value"}'
+
+
+def test_save_agent_messages_basic():
+    """Test basic save_agent_messages functionality."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        messages = cast(
+            list[LiteLLMMessage],
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there"},
+            ],
+        )
+
+        result_path = save_agent_messages(
+            messages=messages,
+            task_id="test_task",
+            agent_name="test_agent",
+            output_dir=temp_dir,
+        )
+
+        assert Path(result_path).exists()
+        assert Path(result_path).parent == Path(temp_dir)
+
+        # Check file content
+        with open(result_path) as f:
+            data = json.load(f)
+
+        assert data["task_id"] == "test_task"
+        assert data["agent"] == "test_agent"
+        assert "timestamp" in data
+        assert data["messages"] == messages
+
+
+def test_save_agent_messages_with_tools():
+    """Test save_agent_messages with tools."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+        tools = [{"name": "test_tool", "description": "A test tool"}]
+
+        result_path = save_agent_messages(
+            messages=messages,
+            task_id="test_task",
+            agent_name="test_agent",
+            output_dir=temp_dir,
+            tools=tools,
+        )
+
+        with open(result_path) as f:
+            data = json.load(f)
+
+        assert data["tools"] == tools
+
+
+def test_save_agent_messages_creates_directory():
+    """Test that save_agent_messages creates output directory."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir) / "new_logs"
+
+        messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+        result_path = save_agent_messages(
+            messages=messages,
+            task_id="test_task",
+            agent_name="test_agent",
+            output_dir=str(output_dir),
+        )
+
+        assert output_dir.exists()
+        assert Path(result_path).exists()
+
+
+@patch("corral.agents.utils.datetime")
+def test_save_agent_messages_filename_format(mock_datetime):
+    """Test that save_agent_messages generates correct filename format."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        messages = cast(list[LiteLLMMessage], [{"role": "user", "content": "Hello"}])
+
+        mock_datetime.now.return_value.strftime.return_value = "20240101_120000"
+
+        result_path = save_agent_messages(
+            messages=messages,
+            task_id="test_task",
+            agent_name="test_agent",
+            output_dir=temp_dir,
+        )
+
+        expected_filename = "test_task_20240101_120000.json"
+        assert Path(result_path).name == expected_filename
+
+
+def test_tool_conversion_pipeline():
+    """Test the complete tool conversion pipeline."""
+    tools_dict = {
+        "tools": [
+            {
+                "name": "calculator",
+                "description": "Perform math operations",
+                "arguments": [
+                    "operation (str, required): The operation to perform",
+                    "x (float, required): First number",
+                    "y (float, optional, default: 1.0): Second number",
+                ],
+            }
+        ]
+    }
+
+    # Convert to OpenAI format
+    openai_tools = convert_to_openai_tool_format(tools_dict)
+
+    # Verify the conversion worked correctly
+    assert len(openai_tools) == 1
+    tool = openai_tools[0]
+    assert tool["type"] == "function"
+    assert tool["function"]["name"] == "calculator"
+
+    # Check parameters
+    params = tool["function"]["parameters"]
+    assert "operation" in params["properties"]
+    assert "x" in params["properties"]
+    assert "y" in params["properties"]
+    assert params["required"] == ["operation", "x"]
+    assert params["properties"]["y"]["default"] == "1.0"
+
+
+def test_message_serialization_and_saving():
+    """Test message serialization and saving working together."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create mock messages with various types
+        mock_message1 = Mock()
+        mock_message1.role = "user"
+        mock_message1.content = "Hello"
+        mock_message1.tool_call_id = None
+        mock_message1.name = None
+        mock_message1.tool_calls = None
+
+        mock_message2 = {"role": "assistant", "content": "Hi there"}
+
+        messages = [mock_message1, mock_message2]
+
+        # Save messages
+        result_path = save_agent_messages(
+            messages=messages,
+            task_id="integration_test",
+            agent_name="test_agent",
+            output_dir=temp_dir,
+        )
+
+        # Load and verify
+        with open(result_path) as f:
+            data = json.load(f)
+
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][0]["content"] == "Hello"
+        assert data["messages"][1] == mock_message2


### PR DESCRIPTION
## Summary by Sourcery

Enable ChemBench task execution by spinning up a benchmark server that loads and filters the HuggingFace ChemBench dataset, uses a configurable CLI, and ships a comprehensive test suite for agents and utilities

New Features:
- Integrate ChemBench environment with a benchmark server and Uvicorn for running ChemBench tasks
- Load and filter ChemBench dataset from HuggingFace configs, selecting tasks in the human subset
- Expose a CLI entrypoint (via fire) to configure port and working directory for ChemBench runs

Enhancements:
- Disable deprecated PubChem tools in ChemBench environment and allow customizing work_dir in ChemBenchEnvironment
- Improve task filtering by checking human subset flags before creating environments

Tests:
- Add comprehensive tests for ToolCallingAgent covering tool invocation, error handling, and final answer extraction
- Add extensive tests for ReActAgent parsing, tool execution flow, and edge cases
- Add tests for BaseAgent logic, LLM response handling, run_agent flow, and token usage tracking
- Add tests for agent utilities and prompt_utils to validate prompt creation, formatting, and LLM call behavior