### PR TITLE
chore: switch the MD setup to monorepo setup

### DIFF
--- a/tasks/corral_md/pyproject.toml
+++ b/tasks/corral_md/pyproject.toml
@@ -24,6 +24,6 @@ dependencies = [
     "streamlit>=1.46.1"
 ]
 [tool.uv.sources]
-corral = { git = "https://github.com/lamalab-org/mat-agent-bench.git", branch = "main" } #TODO: change to main branch when merged
+corral = { path = "../..", editable = true }
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
we did not fully migrate to separate out the envs as packages.  thus, the envs should still indicate dependency as in a monorepo.  this will make the ci easier