### PR TITLE
feat: add configure external services at start of a trail

### DIFF
--- a/src/corral/backend/env.py
+++ b/src/corral/backend/env.py
@@ -400,3 +400,10 @@ class Environment(ABC):
         ]
 
         return stats
+
+    def configure_additional_apps(self):
+        """Configure any external apps/services (for example, experimental instruments or robots) needed for the environment.
+        This method is called at the start of each trial."""
+        # This can be overridden by subclasses to set up external dependencies
+
+        return "No external app/service configuration needed for this trial."

--- a/src/corral/backend/server.py
+++ b/src/corral/backend/server.py
@@ -214,7 +214,20 @@ def create_benchmark_server(environments: dict[str, Environment]) -> FastAPI:
             raise HTTPException(status_code=404, detail="Trial not found")
         return {"trial_state": trial_state}
 
-    # add endpoint for scoring the task
+    @app.post("/tasks/{task_id}/configure")
+    def configure_additional_apps(task_id: str):
+        """Configure external apps/services for this specific task at the beginning of each trail"""
+        if task_id not in environments:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        env = environments[task_id]
+        status = env.configure_additional_apps()
+
+        return {
+            "status": status,
+            "task_id": task_id,
+            "trial_id": env.state.trial_id,
+        }
 
     return app
 

--- a/src/corral/router/routes.py
+++ b/src/corral/router/routes.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import requests
+import requests  # type: ignore[import-untyped]
 from loguru import logger
 
 from corral.report.results import TaskTrialResult
@@ -120,8 +120,20 @@ class CorralRouter:
         response.raise_for_status()
         return response.json()["trial_state"]
 
-    def configure_additional_apps(self, task_id: str) -> dict:
-        """Configure additional apps/services for specific task"""
-        response = requests.post(f"{self.base_url}/tasks/{task_id}/configure")
+    def configure_additional_apps(
+        self, task_id: str, timeout: float | None = None
+    ) -> dict:
+        """Configure additional apps/services for specific task
+
+        Args:
+            task_id: The task identifier to configure.
+            timeout: Optional timeout in seconds for the HTTP request.
+        """
+        if timeout is None:
+            response = requests.post(f"{self.base_url}/tasks/{task_id}/configure")
+        else:
+            response = requests.post(
+                f"{self.base_url}/tasks/{task_id}/configure", timeout=timeout
+            )
         response.raise_for_status()
         return response.json()

--- a/src/corral/router/routes.py
+++ b/src/corral/router/routes.py
@@ -119,3 +119,9 @@ class CorralRouter:
         response = requests.get(f"{self.base_url}/tasks/{task_id}/trials/{trial_id}")
         response.raise_for_status()
         return response.json()["trial_state"]
+
+    def configure_additional_apps(self, task_id: str) -> dict:
+        """Configure additional apps/services for specific task"""
+        response = requests.post(f"{self.base_url}/tasks/{task_id}/configure")
+        response.raise_for_status()
+        return response.json()

--- a/src/corral/run.py
+++ b/src/corral/run.py
@@ -62,13 +62,12 @@ def execute_single_trial(
 ) -> TaskTrialResult:
     """Execute a single trial - pure function"""
     try:
-        # Run agent
-        if tool_verbosity is not None:
-            answer, token_usage = agent.run_agent(
-                interface, task_id, verbose=verbose, tool_verbosity=tool_verbosity
-            )
-        else:
-            answer, token_usage = agent.run_agent(interface, task_id, verbose=verbose)
+        status = interface.configure_additional_apps(task_id)
+        logger.info(f"Task {task_id} additional apps/services configured: {status}")
+
+        answer, token_usage = agent.run_agent(
+            interface, task_id, verbose=verbose, tool_verbosity=tool_verbosity
+        )
 
         # Submit answer
         try:

--- a/src/corral/run.py
+++ b/src/corral/run.py
@@ -59,14 +59,18 @@ def execute_single_trial(
     agent: BaseAgent,
     verbose: bool = False,
     tool_verbosity: str | None = None,
+    configure_timeout: float | None = None,
 ) -> TaskTrialResult:
     """Execute a single trial - pure function"""
     try:
-        status = interface.configure_additional_apps(task_id)
+        status = interface.configure_additional_apps(task_id, timeout=configure_timeout)
         logger.info(f"Task {task_id} additional apps/services configured: {status}")
 
         answer, token_usage = agent.run_agent(
-            interface, task_id, verbose=verbose, tool_verbosity=tool_verbosity
+            interface,
+            task_id,
+            verbose=verbose,
+            tool_verbosity=tool_verbosity or "brief",
         )
 
         # Submit answer
@@ -198,6 +202,7 @@ class CorralRunner:
         verbose: bool = False,
         session_id: str | None = None,
         tool_verbosity: str | None = None,
+        configure_timeout: float | None = None,
     ) -> BenchmarkResult:
         """Run benchmark with functional approach"""
 
@@ -224,6 +229,7 @@ class CorralRunner:
                 agent=self.agent,
                 verbose=verbose,
                 tool_verbosity=tool_verbosity,
+                configure_timeout=configure_timeout,
             )
 
         checkpoint_saver = partial(self._save_checkpoint, session_id)

--- a/tests/test_configure_additional_apps.py
+++ b/tests/test_configure_additional_apps.py
@@ -15,7 +15,7 @@ class DummyEnv(Environment):
         return 1.0
 
     def configure_additional_apps(self):
-        return "configured ok"
+        return "No external app/service configuration needed for this trial."
 
 
 def create_app_with_env(task_id: str = "task_a") -> TestClient:
@@ -31,7 +31,10 @@ class TestConfigureAdditionalAppsEndpoint:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "configured ok"
+        assert (
+            data["status"]
+            == "No external app/service configuration needed for this trial."
+        )
         assert data["task_id"] == "task_a"
         # trial_id starts at "0" on first reset_state during env init
         assert data["trial_id"] == "0"
@@ -64,3 +67,23 @@ class TestCorralRouterConfigureAdditionalApps:
         assert data["trial_id"] == "3"
 
         mock_post.assert_called_once_with("http://example.com/tasks/task_a/configure")
+
+    def test_router_passes_timeout_when_provided(self):
+        router = CorralRouter(base_url="http://example.com")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "ok",
+            "task_id": "t",
+            "trial_id": "1",
+        }
+
+        with patch(
+            "corral.router.routes.requests.post", return_value=mock_response
+        ) as mock_post:
+            _ = router.configure_additional_apps("t", timeout=5.5)
+
+        mock_post.assert_called_once_with(
+            "http://example.com/tasks/t/configure", timeout=5.5
+        )

--- a/tests/test_configure_additional_apps.py
+++ b/tests/test_configure_additional_apps.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from corral.backend.env import Environment
+from corral.backend.server import create_benchmark_server
+from corral.router.routes import CorralRouter
+
+
+class DummyEnv(Environment):
+    def get_task_prompt(self) -> str | list[dict]:
+        return "dummy prompt"
+
+    def score(self) -> float:
+        return 1.0
+
+    def configure_additional_apps(self):
+        return "configured ok"
+
+
+def create_app_with_env(task_id: str = "task_a") -> TestClient:
+    env = DummyEnv(task_id=task_id, base_work_dir="", fs_manager=None)
+    app = create_benchmark_server({task_id: env})
+    return TestClient(app)
+
+
+class TestConfigureAdditionalAppsEndpoint:
+    def test_successful_configuration_returns_status_and_ids(self):
+        client = create_app_with_env("task_a")
+        response = client.post("/tasks/task_a/configure")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "configured ok"
+        assert data["task_id"] == "task_a"
+        # trial_id starts at "0" on first reset_state during env init
+        assert data["trial_id"] == "0"
+
+    def test_unknown_task_returns_404(self):
+        client = create_app_with_env("task_a")
+        response = client.post("/tasks/unknown/configure")
+        assert response.status_code == 404
+
+
+class TestCorralRouterConfigureAdditionalApps:
+    def test_router_calls_configure_endpoint_and_returns_json(self):
+        router = CorralRouter(base_url="http://example.com")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "configured ok",
+            "task_id": "task_a",
+            "trial_id": "3",
+        }
+
+        with patch(
+            "corral.router.routes.requests.post", return_value=mock_response
+        ) as mock_post:
+            data = router.configure_additional_apps("task_a")
+
+        assert data["status"] == "configured ok"
+        assert data["task_id"] == "task_a"
+        assert data["trial_id"] == "3"
+
+        mock_post.assert_called_once_with("http://example.com/tasks/task_a/configure")


### PR DESCRIPTION
## Summary by Sourcery

Add support for configuring external applications and services at the beginning of each trial by exposing a new API endpoint, integrating it into the trial runner, and providing default and client-side implementations.

New Features:
- Add /tasks/{task_id}/configure endpoint to initialize task-specific external services at the start of each trial
- Invoke interface.configure_additional_apps in the trial execution flow and log the configuration status before running the agent
- Add a default configure_additional_apps method to the Environment base class for subclasses to override
- Implement configure_additional_apps in the API router client to call the new server endpoint