### PR TITLE
fix: change ReAct prompt to only asking for XML tags

### DIFF
--- a/src/corral/agents/prompts/index.json
+++ b/src/corral/agents/prompts/index.json
@@ -22,12 +22,12 @@
   },
   "d880c4d3-fe60-4cf4-813b-2008076cd595": {
     "uuid": "d880c4d3-fe60-4cf4-813b-2008076cd595",
-    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For empty action input, use empty JSON `{}`.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
     "description": "Very basic REACT prompt. Intended for use with LLM agents.",
     "version": 1,
     "versions": [
       {
-        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For empty action input, use empty JSON `{}`.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
         "description": "Very basic REACT prompt. Intended for use with LLM agents.",
         "version": 1,
         "created_at": "2025-03-03T12:16:29.129829"

--- a/src/corral/agents/prompts/index.json
+++ b/src/corral/agents/prompts/index.json
@@ -22,12 +22,12 @@
   },
   "d880c4d3-fe60-4cf4-813b-2008076cd595": {
     "uuid": "d880c4d3-fe60-4cf4-813b-2008076cd595",
-    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For empty action input, use empty JSON `{}`.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
     "description": "Very basic REACT prompt. Intended for use with LLM agents.",
     "version": 1,
     "versions": [
       {
-        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For empty action input, use empty JSON `{}`.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
         "description": "Very basic REACT prompt. Intended for use with LLM agents.",
         "version": 1,
         "created_at": "2025-03-03T12:16:29.129829"

--- a/src/corral/agents/prompts/index.json
+++ b/src/corral/agents/prompts/index.json
@@ -22,12 +22,12 @@
   },
   "d880c4d3-fe60-4cf4-813b-2008076cd595": {
     "uuid": "d880c4d3-fe60-4cf4-813b-2008076cd595",
-    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\nThought: <thought>[your reasoning]</thought>\nAction: <action>[tool name]</action>\nAction Input: <action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\nThought: <thought>[your reasoning]</thought>\nFinal Answer: <final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
     "description": "Very basic REACT prompt. Intended for use with LLM agents.",
     "version": 1,
     "versions": [
       {
-        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\nThought: <thought>[your reasoning]</thought>\nAction: <action>[tool name]</action>\nAction Input: <action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\nThought: <thought>[your reasoning]</thought>\nFinal Answer: <final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
         "description": "Very basic REACT prompt. Intended for use with LLM agents.",
         "version": 1,
         "created_at": "2025-03-03T12:16:29.129829"

--- a/src/corral/agents/react.py
+++ b/src/corral/agents/react.py
@@ -119,10 +119,7 @@ class ReActAgent(BaseAgent):
         for action_match in action_matches:
             tool_name = action_match.group(1).strip()
             try:
-                if action_match.group(2) is None:
-                    action_input = "{}"
-                else:
-                    action_input = action_match.group(2).strip()
+                action_input = action_match.group(2).strip()
 
                 converted_input = convert_outermost_triple_quotes(action_input)
 
@@ -215,7 +212,7 @@ class ReActAgent(BaseAgent):
                 self.messages.append(
                     LiteLLMMessage(
                         role="user",
-                        content="No actions to execute. This is due to parsing error or missing action in the response. Please use the tags <thought>, <action> and <action_input> to specify your action, or <final_answer> to provide your final answer.",
+                        content="No actions to execute. This is due to parsing error or missing action in the response. Please follow the format <thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>. Remember the closing tags. For empty action input, use empty JSON `{}`. Try again.",
                     )
                 )
 

--- a/src/corral/agents/react.py
+++ b/src/corral/agents/react.py
@@ -119,7 +119,18 @@ class ReActAgent(BaseAgent):
         for action_match in action_matches:
             tool_name = action_match.group(1).strip()
             try:
-                action_input = action_match.group(2).strip()
+                action_input = action_match.group(2)
+                if action_input is None and (
+                    "</action_input>" not in response
+                    or "<action_input>" not in response
+                ):
+                    action_input = "{}"  # Default to empty JSON object if no tags found for action_input
+                elif action_input is None and (
+                    "</action_input>" in response and "<action_input>" in response
+                ):
+                    return thoughts, None
+                else:
+                    action_input = action_match.group(2).strip()
 
                 converted_input = convert_outermost_triple_quotes(action_input)
 
@@ -212,7 +223,7 @@ class ReActAgent(BaseAgent):
                 self.messages.append(
                     LiteLLMMessage(
                         role="user",
-                        content="No actions to execute. This is due to parsing error or missing action in the response. Please follow the format <thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>. Remember the closing tags. For empty action input, use empty JSON `{}`. Try again.",
+                        content="No actions to execute. This is due to parsing error or missing action in the response. Please follow the format <thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>. Remember the closing tags. Try again.",
                     )
                 )
 

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -290,8 +290,6 @@ def parse_string_argument(arg_string: str) -> dict | None:
     Parse a string argument format like "path (str, required): Path to the directory"
     This is a fallback for malformed API responses.
     """
-    import re
-
     # Pattern to match "name (type, required/optional): description"
     pattern = r"^(\w+)\s*\(([^,]+)(?:,\s*(required|optional))?\):\s*(.+)$"
     match = re.match(pattern, arg_string.strip())


### PR DESCRIPTION
## Summary by Sourcery

Update the ReAct prompt to only request XML tags and remove an unnecessary import in the string parsing utility.

Bug Fixes:
- Limit the ReAct prompt to ask only for XML tags

Enhancements:
- Remove redundant import of the 're' module in parse_string_argument