### PR TITLE
fix: correct ReAct behaviour with empty arguments

### DIFF
--- a/src/corral/agents/prompts/index.json
+++ b/src/corral/agents/prompts/index.json
@@ -22,12 +22,12 @@
   },
   "d880c4d3-fe60-4cf4-813b-2008076cd595": {
     "uuid": "d880c4d3-fe60-4cf4-813b-2008076cd595",
-    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+    "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For tool calls without arguments, use `<action_input>{}</action_input>`\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
     "description": "Very basic REACT prompt. Intended for use with LLM agents.",
     "version": 1,
     "versions": [
       {
-        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
+        "content": "Task Guide: {{task_guide}}\n\n{{examples}}\n\nThink about what to do next and respond in the following format:\n\n<thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>. For tool calls without arguments, use `<action_input>{}</action_input>`\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>\n\nThe code expects the XML tags to be used exactly as shown. If this format is not followed, the regex parsing will not work.",
         "description": "Very basic REACT prompt. Intended for use with LLM agents.",
         "version": 1,
         "created_at": "2025-03-03T12:16:29.129829"

--- a/src/corral/agents/react.py
+++ b/src/corral/agents/react.py
@@ -120,14 +120,8 @@ class ReActAgent(BaseAgent):
             tool_name = action_match.group(1).strip()
             try:
                 action_input = action_match.group(2)
-                if action_input is None and (
-                    "</action_input>" not in response
-                    or "<action_input>" not in response
-                ):
-                    action_input = "{}"  # Default to empty JSON object if no tags found for action_input
-                elif action_input is None and (
-                    "</action_input>" in response and "<action_input>" in response
-                ):
+                # Check if action_input tags are malformed (opening tag present but closing tag missing)
+                if action_input is None:
                     return thoughts, None
                 else:
                     action_input = action_match.group(2).strip()
@@ -223,7 +217,7 @@ class ReActAgent(BaseAgent):
                 self.messages.append(
                     LiteLLMMessage(
                         role="user",
-                        content="No actions to execute. This is due to parsing error or missing action in the response. Please follow the format <thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>. Remember the closing tags. Try again.",
+                        content="No actions to execute. This is due to parsing error or missing action in the response. Please follow the format <thought>[your reasoning]</thought>\n<action>[tool name]</action>\n<action_input>[tool arguments as JSON]</action_input>.\n\nIf you have the final answer, respond with:\n<thought>[your reasoning]</thought>\n<final_answer>[answer]</final_answer>. For tool calls without arguments, use `<action_input>{}</action_input>`. Remember the closing tags. Try again.",
                     )
                 )
 


### PR DESCRIPTION
## Summary by Sourcery

Fix ReAct parsing logic to no longer silently default missing action input to `{}`, and update agent prompts to explicitly require empty JSON tags for no-argument tool calls.

Bug Fixes:
- Treat missing or malformed <action_input> tags as a parsing error instead of defaulting to an empty JSON object
- Clarify in the user-facing message that tool calls without arguments must use `<action_input>{}</action_input>`