### PR TITLE
feat: add tests to the spectra elucidation environment

### DIFF
--- a/tasks/spectra_elucidation/spectra_elucidation/score.py
+++ b/tasks/spectra_elucidation/spectra_elucidation/score.py
@@ -184,7 +184,7 @@ def score_molecule_fragments(prediction: list[str], ground_truth: str) -> float:
         return 0.0
 
     if not seq:  # Empty list
-        return 1.0
+        return 0.0
 
     target_mol = Chem.MolFromSmiles(ground_truth)
     if target_mol is None:

--- a/tasks/spectra_elucidation/spectra_elucidation/spectra_utils.py
+++ b/tasks/spectra_elucidation/spectra_elucidation/spectra_utils.py
@@ -1,0 +1,272 @@
+import re
+from collections import Counter
+from itertools import combinations
+
+import requests
+from rdkit import Chem
+
+_ELEMENT_PAT = re.compile(r"([A-Z][a-z]?)(\d*)")
+_PAREN_PAT = re.compile(r"\(([^()]*)\)(\d*)")
+_DOT_PAT = re.compile(r"·|\.")
+
+
+def differs_by_one_atom(parent_formula, fragment_formula):
+    """Check if fragment differs from parent by exactly one atom"""
+    total_diff = 0
+    all_elements = set(parent_formula.keys()) | set(fragment_formula.keys())
+
+    for element in all_elements:
+        parent_count = parent_formula.get(element, 0)
+        fragment_count = fragment_formula.get(element, 0)
+        diff = abs(parent_count - fragment_count)
+        total_diff += diff
+
+    # If total difference is exactly 1, it means one atom was added/removed
+    return total_diff == 1 or total_diff == 0
+
+
+def _parse_simple(formula: str) -> dict[str, int]:
+    """
+    Parse an already-expanded, dot-free formula into {element: count}.
+    """
+    counts = Counter()
+    for el, cnt in _ELEMENT_PAT.findall(formula):
+        counts[el] += int(cnt or 1)
+    return counts
+
+
+def _expand_parentheses(formula: str) -> str:
+    """
+    Recursively expand parentheses so that C6H5(CH3) becomes C6H5C1H3 etc.
+    """
+    while True:
+        m = _PAREN_PAT.search(formula)
+        if not m:
+            return formula
+        inner, mult = m.groups()
+        mult = int(mult or 1)
+        expanded = "".join(
+            f"{el}{int(cnt or 1)*mult}" for el, cnt in _ELEMENT_PAT.findall(inner)
+        )
+        formula = formula[: m.start()] + expanded + formula[m.end() :]
+
+
+def parse_molecular_formula(formula: str) -> dict[str, int]:
+    """
+    Parse molecular formula into an element-count mapping, handling
+    parentheses and dot adducts.
+    """
+    parts = _DOT_PAT.split(formula.replace(" ", ""))
+    total = Counter()
+    for part in parts:
+        expanded = _expand_parentheses(part)
+        total += _parse_simple(expanded)
+    return dict(total)
+
+
+def enumerate_fragments_from_smiles(
+    smi: str,
+    max_cuts: int = 2,
+    skip_ring_bonds: bool = True,
+    min_heavy_atoms: int = 2,
+    max_combos: int = 100000,
+):
+    """
+    Generate fragment SMILES by breaking up to `max_cuts` bonds.
+    Returns a sorted list of unique canonical SMILES of fragments.
+    Preserves ions by setting formal charges instead of adding hydrogens.
+    """
+    mol = Chem.MolFromSmiles(smi)
+    if mol is None:
+        raise ValueError("Invalid SMILES")
+
+    # Candidate bonds: heavy-atom bonds only; optionally skip ring bonds
+    cand_bond_idxs = []
+    for b in mol.GetBonds():
+        a1, a2 = b.GetBeginAtom(), b.GetEndAtom()
+        if a1.GetAtomicNum() == 1 or a2.GetAtomicNum() == 1:
+            continue
+        if skip_ring_bonds and b.IsInRing():
+            continue
+        cand_bond_idxs.append(b.GetIdx())
+
+    # Early exit: nothing to cut
+    if not cand_bond_idxs or max_cuts < 1:
+        return []
+
+    uniq = set()
+    tried = 0
+
+    for ncuts in range(1, min(max_cuts, len(cand_bond_idxs)) + 1):
+        for cutset in combinations(cand_bond_idxs, ncuts):
+            tried += 1
+            if tried > max_combos:
+                # Safety valve against combinatorial explosion
+                break
+
+            rw = Chem.RWMol(mol)
+            cut_atom_info = {}
+
+            # Count how many bonds each atom will lose
+            for bidx in cutset:
+                b = rw.GetBondWithIdx(bidx)
+                begin_idx = b.GetBeginAtomIdx()
+                end_idx = b.GetEndAtomIdx()
+
+                cut_atom_info[begin_idx] = cut_atom_info.get(begin_idx, 0) + 1
+                cut_atom_info[end_idx] = cut_atom_info.get(end_idx, 0) + 1
+
+            # Before removing bonds, adjust formal charges on cut atoms
+            for atom_idx, bonds_lost in cut_atom_info.items():
+                atom = rw.GetAtomWithIdx(atom_idx)
+                current_charge = atom.GetFormalCharge()
+
+                # Adjust charge based on bonds lost
+                new_charge = current_charge - bonds_lost
+                atom.SetFormalCharge(new_charge)
+
+            # Now remove the selected bonds
+            for bidx in sorted(
+                cutset, reverse=True
+            ):  # Remove in reverse order to maintain indices
+                b = rw.GetBondWithIdx(bidx)
+                rw.RemoveBond(b.GetBeginAtomIdx(), b.GetEndAtomIdx())
+
+            # Get connected components as fragments
+            try:
+                frags = Chem.rdmolops.GetMolFrags(
+                    rw.GetMol(), asMols=True, sanitizeFrags=False
+                )
+
+                for frag in frags:
+                    # Filter tiny pieces
+                    if (
+                        sum(1 for a in frag.GetAtoms() if a.GetAtomicNum() > 1)
+                        < min_heavy_atoms
+                    ):
+                        continue
+
+                    try:
+                        # Try to sanitize the fragment with ionic charges
+                        Chem.SanitizeMol(frag, catchErrors=False)
+                        smi_frag = Chem.MolToSmiles(
+                            frag, isomericSmiles=True, canonical=True
+                        )
+                        uniq.add(smi_frag)
+                    except Exception:
+                        # If sanitization fails with ionic charges, try without sanitization
+                        try:
+                            smi_frag = Chem.MolToSmiles(
+                                frag, isomericSmiles=True, canonical=True
+                            )
+                            uniq.add(smi_frag)
+                        except Exception:
+                            continue  # Skip this fragment if it can't be processed
+
+            except Exception:
+                # If fragmentation fails completely, skip this cut combination
+                continue
+
+        else:
+            continue
+        break  # broke due to max_combos
+
+    return sorted(uniq)
+
+
+def format_hsqc_spectrum(zones_dict: dict) -> str:
+    """
+    Parse HSQC spectra data from dictionary format to standard NMR notation.
+
+    Args:
+        zones_dict (dict): Dictionary containing zones data with signals
+        frequency (str): NMR frequency (default: "600 MHz")
+        solvent (str): NMR solvent (default: "DMSO-d6")
+
+    Returns:
+        str: Formatted HSQC notation string
+    """
+    if "zones" not in zones_dict or "values" not in zones_dict["zones"]:
+        return "Invalid input format"
+
+    signals_data = []
+
+    # Extract signals from each zone
+    for zone in zones_dict["zones"]["values"]:
+        if "signals" in zone:
+            for signal in zone["signals"]:
+                # Extract chemical shifts
+                h_delta = signal["x"]["delta"]  # 1H chemical shift
+                c_delta = signal["y"]["delta"]  # 13C chemical shift
+
+                # Count hydrogen atoms from x.atoms (1H nuclei)
+                h_count = len(signal["x"]["atoms"]) if "atoms" in signal["x"] else 1
+
+                # Store the data for sorting
+                signals_data.append(
+                    {"h_delta": h_delta, "c_delta": c_delta, "h_count": h_count}
+                )
+
+    # Sort signals by 1H chemical shift (ascending order)
+    signals_data.sort(key=lambda x: x["h_delta"])
+
+    # Format each signal
+    formatted_signals = []
+    for signal in signals_data:
+        h_delta = signal["h_delta"]
+        c_delta = signal["c_delta"]
+        h_count = signal["h_count"]
+
+        # Format chemical shifts (remove trailing zeros)
+        h_str = f"{h_delta:.2f}".rstrip("0").rstrip(".")
+        c_str = f"{c_delta:.1f}".rstrip("0").rstrip(".")
+
+        # Create the signal string
+        signal_str = f"{h_str}/{c_str} ({h_count}H)"
+        formatted_signals.append(signal_str)
+
+    # Combine all signals
+    signals_part = ", ".join(formatted_signals)
+
+    # Create final HSQC string
+    return f"HSQC: delta H/delta C {signals_part}."
+
+
+def convert_ms_spectrum_to_string(spectrum_data):
+    """
+    Convert MS spectrum data from JSON format to string format.
+
+    Args:
+        spectrum_data (list): List of dictionaries with 'x' (m/z) and 'y' (intensity) keys
+
+    Returns:
+        str: Formatted string in the format "m/z 100.1 (intensity 500), 101.2 (intensity 450), ..."
+    """
+    if not spectrum_data:
+        return ""
+
+    # Convert each data point to the desired format
+    formatted_peaks = []
+    for peak in spectrum_data:
+        mz = peak["x"]
+        intensity = peak["y"]
+        formatted_peaks.append(f"{mz} (intensity {intensity})")
+
+    # Join all peaks with ", " and prepend "m/z "
+    return "m/z " + ", ".join(formatted_peaks)
+
+
+def make_api_call(url: str, payload: dict) -> dict:
+    """
+    Make a POST request to the specified URL with the given payload.
+
+    Args:
+        url (str): The URL to which the request is sent.
+        payload (dict): The data to be sent in the request body.
+
+    Returns:
+        dict: The JSON response from the server.
+    """
+    resp = requests.post(url, json=payload)
+    resp.raise_for_status()
+    return resp.json()

--- a/tasks/spectra_elucidation/spectra_elucidation/spectra_utils.py
+++ b/tasks/spectra_elucidation/spectra_elucidation/spectra_utils.py
@@ -10,21 +10,6 @@ _PAREN_PAT = re.compile(r"\(([^()]*)\)(\d*)")
 _DOT_PAT = re.compile(r"·|\.")
 
 
-def differs_by_one_atom(parent_formula, fragment_formula):
-    """Check if fragment differs from parent by exactly one atom"""
-    total_diff = 0
-    all_elements = set(parent_formula.keys()) | set(fragment_formula.keys())
-
-    for element in all_elements:
-        parent_count = parent_formula.get(element, 0)
-        fragment_count = fragment_formula.get(element, 0)
-        diff = abs(parent_count - fragment_count)
-        total_diff += diff
-
-    # If total difference is exactly 1, it means one atom was added/removed
-    return total_diff == 1 or total_diff == 0
-
-
 def _parse_simple(formula: str) -> dict[str, int]:
     """
     Parse an already-expanded, dot-free formula into {element: count}.

--- a/tasks/spectra_elucidation/spectra_elucidation/tools.py
+++ b/tasks/spectra_elucidation/spectra_elucidation/tools.py
@@ -1,23 +1,21 @@
 import random
-import re
 import traceback
-from collections import Counter
-from itertools import combinations
 from pathlib import Path
 from typing import Any
 
 import modal
-import requests
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
+from spectra_elucidation.spectra_utils import (
+    convert_ms_spectrum_to_string,
+    enumerate_fragments_from_smiles,
+    format_hsqc_spectrum,
+    make_api_call,
+)
 
 from corral.backend.tool import Tool, tool
 from corral.utils.modal import remote_call
 from corral.utils.rag import vector_database_search
-
-_ELEMENT_PAT = re.compile(r"([A-Z][a-z]?)(\d*)")
-_PAREN_PAT = re.compile(r"\(([^()]*)\)(\d*)")
-_DOT_PAT = re.compile(r"·|\.")
 
 get_isomers = modal.Function.lookup("chemenv", "get_compound_isomers_pubchem")
 
@@ -575,80 +573,6 @@ def ir_spectra(h_smiles: str) -> str:
     )
 
 
-def make_api_call(url: str, payload: dict) -> dict:
-    """
-    Make a POST request to the specified URL with the given payload.
-
-    Args:
-        url (str): The URL to which the request is sent.
-        payload (dict): The data to be sent in the request body.
-
-    Returns:
-        dict: The JSON response from the server.
-    """
-    resp = requests.post(url, json=payload)
-    resp.raise_for_status()
-    return resp.json()
-
-
-def format_hsqc_spectrum(zones_dict: dict) -> str:
-    """
-    Parse HSQC spectra data from dictionary format to standard NMR notation.
-
-    Args:
-        zones_dict (dict): Dictionary containing zones data with signals
-        frequency (str): NMR frequency (default: "600 MHz")
-        solvent (str): NMR solvent (default: "DMSO-d6")
-
-    Returns:
-        str: Formatted HSQC notation string
-    """
-    if "zones" not in zones_dict or "values" not in zones_dict["zones"]:
-        return "Invalid input format"
-
-    signals_data = []
-
-    # Extract signals from each zone
-    for zone in zones_dict["zones"]["values"]:
-        if "signals" in zone:
-            for signal in zone["signals"]:
-                # Extract chemical shifts
-                h_delta = signal["x"]["delta"]  # 1H chemical shift
-                c_delta = signal["y"]["delta"]  # 13C chemical shift
-
-                # Count hydrogen atoms from x.atoms (1H nuclei)
-                h_count = len(signal["x"]["atoms"]) if "atoms" in signal["x"] else 1
-
-                # Store the data for sorting
-                signals_data.append(
-                    {"h_delta": h_delta, "c_delta": c_delta, "h_count": h_count}
-                )
-
-    # Sort signals by 1H chemical shift (ascending order)
-    signals_data.sort(key=lambda x: x["h_delta"])
-
-    # Format each signal
-    formatted_signals = []
-    for signal in signals_data:
-        h_delta = signal["h_delta"]
-        c_delta = signal["c_delta"]
-        h_count = signal["h_count"]
-
-        # Format chemical shifts (remove trailing zeros)
-        h_str = f"{h_delta:.2f}".rstrip("0").rstrip(".")
-        c_str = f"{c_delta:.1f}".rstrip("0").rstrip(".")
-
-        # Create the signal string
-        signal_str = f"{h_str}/{c_str} ({h_count}H)"
-        formatted_signals.append(signal_str)
-
-    # Combine all signals
-    signals_part = ", ".join(formatted_signals)
-
-    # Create final HSQC string
-    return f"HSQC: delta H/delta C {signals_part}."
-
-
 @tool(hidden_args=["h_smiles"])
 def hsqc_nmr_spectra(h_smiles: str) -> str:
     """[BRIEF] Returns the HSQC (Heteronuclear Single Quantum Coherence) NMR spectra for the sample at hand. [/BRIEF]
@@ -712,30 +636,6 @@ def hsqc_nmr_spectra(h_smiles: str) -> str:
         if pulse_sequence == "hsqc":
             return format_hsqc_spectrum(spectrum)
     return "No HSQC spectrum found for the provided SMILES."
-
-
-def convert_ms_spectrum_to_string(spectrum_data):
-    """
-    Convert MS spectrum data from JSON format to string format.
-
-    Args:
-        spectrum_data (list): List of dictionaries with 'x' (m/z) and 'y' (intensity) keys
-
-    Returns:
-        str: Formatted string in the format "m/z 100.1 (intensity 500), 101.2 (intensity 450), ..."
-    """
-    if not spectrum_data:
-        return ""
-
-    # Convert each data point to the desired format
-    formatted_peaks = []
-    for peak in spectrum_data:
-        mz = peak["x"]
-        intensity = peak["y"]
-        formatted_peaks.append(f"{mz} (intensity {intensity})")
-
-    # Join all peaks with ", " and prepend "m/z "
-    return "m/z " + ", ".join(formatted_peaks)
 
 
 @tool(hidden_args=["h_smiles"])
@@ -1128,170 +1028,6 @@ def validate_smiles(smiles: str) -> bool:
     """
     mol = Chem.MolFromSmiles(smiles)
     return mol is not None
-
-
-def differs_by_one_atom(parent_formula, fragment_formula):
-    """Check if fragment differs from parent by exactly one atom"""
-    total_diff = 0
-    all_elements = set(parent_formula.keys()) | set(fragment_formula.keys())
-
-    for element in all_elements:
-        parent_count = parent_formula.get(element, 0)
-        fragment_count = fragment_formula.get(element, 0)
-        diff = abs(parent_count - fragment_count)
-        total_diff += diff
-
-    # If total difference is exactly 1, it means one atom was added/removed
-    return total_diff == 1 or total_diff == 0
-
-
-def _parse_simple(formula: str) -> dict[str, int]:
-    """
-    Parse an already-expanded, dot-free formula into {element: count}.
-    """
-    counts = Counter()
-    for el, cnt in _ELEMENT_PAT.findall(formula):
-        counts[el] += int(cnt or 1)
-    return counts
-
-
-def _expand_parentheses(formula: str) -> str:
-    """
-    Recursively expand parentheses so that C6H5(CH3) becomes C6H5C1H3 etc.
-    """
-    while True:
-        m = _PAREN_PAT.search(formula)
-        if not m:
-            return formula
-        inner, mult = m.groups()
-        mult = int(mult or 1)
-        expanded = "".join(
-            f"{el}{int(cnt or 1)*mult}" for el, cnt in _ELEMENT_PAT.findall(inner)
-        )
-        formula = formula[: m.start()] + expanded + formula[m.end() :]
-
-
-def parse_molecular_formula(formula: str) -> dict[str, int]:
-    """
-    Parse molecular formula into an element-count mapping, handling
-    parentheses and dot adducts.
-    """
-    parts = _DOT_PAT.split(formula.replace(" ", ""))
-    total = Counter()
-    for part in parts:
-        expanded = _expand_parentheses(part)
-        total += _parse_simple(expanded)
-    return dict(total)
-
-
-def enumerate_fragments_from_smiles(
-    smi: str,
-    max_cuts: int = 2,
-    skip_ring_bonds: bool = True,
-    min_heavy_atoms: int = 2,
-    max_combos: int = 100000,
-):
-    """
-    Generate fragment SMILES by breaking up to `max_cuts` bonds.
-    Returns a sorted list of unique canonical SMILES of fragments.
-    Preserves ions by setting formal charges instead of adding hydrogens.
-    """
-    mol = Chem.MolFromSmiles(smi)
-    if mol is None:
-        raise ValueError("Invalid SMILES")
-
-    # Candidate bonds: heavy-atom bonds only; optionally skip ring bonds
-    cand_bond_idxs = []
-    for b in mol.GetBonds():
-        a1, a2 = b.GetBeginAtom(), b.GetEndAtom()
-        if a1.GetAtomicNum() == 1 or a2.GetAtomicNum() == 1:
-            continue
-        if skip_ring_bonds and b.IsInRing():
-            continue
-        cand_bond_idxs.append(b.GetIdx())
-
-    # Early exit: nothing to cut
-    if not cand_bond_idxs or max_cuts < 1:
-        return []
-
-    uniq = set()
-    tried = 0
-
-    for ncuts in range(1, min(max_cuts, len(cand_bond_idxs)) + 1):
-        for cutset in combinations(cand_bond_idxs, ncuts):
-            tried += 1
-            if tried > max_combos:
-                # Safety valve against combinatorial explosion
-                break
-
-            rw = Chem.RWMol(mol)
-            cut_atom_info = {}
-
-            # Count how many bonds each atom will lose
-            for bidx in cutset:
-                b = rw.GetBondWithIdx(bidx)
-                begin_idx = b.GetBeginAtomIdx()
-                end_idx = b.GetEndAtomIdx()
-
-                cut_atom_info[begin_idx] = cut_atom_info.get(begin_idx, 0) + 1
-                cut_atom_info[end_idx] = cut_atom_info.get(end_idx, 0) + 1
-
-            # Before removing bonds, adjust formal charges on cut atoms
-            for atom_idx, bonds_lost in cut_atom_info.items():
-                atom = rw.GetAtomWithIdx(atom_idx)
-                current_charge = atom.GetFormalCharge()
-
-                # Adjust charge based on bonds lost
-                new_charge = current_charge - bonds_lost
-                atom.SetFormalCharge(new_charge)
-
-            # Now remove the selected bonds
-            for bidx in sorted(
-                cutset, reverse=True
-            ):  # Remove in reverse order to maintain indices
-                b = rw.GetBondWithIdx(bidx)
-                rw.RemoveBond(b.GetBeginAtomIdx(), b.GetEndAtomIdx())
-
-            # Get connected components as fragments
-            try:
-                frags = Chem.rdmolops.GetMolFrags(
-                    rw.GetMol(), asMols=True, sanitizeFrags=False
-                )
-
-                for frag in frags:
-                    # Filter tiny pieces
-                    if (
-                        sum(1 for a in frag.GetAtoms() if a.GetAtomicNum() > 1)
-                        < min_heavy_atoms
-                    ):
-                        continue
-
-                    try:
-                        # Try to sanitize the fragment with ionic charges
-                        Chem.SanitizeMol(frag, catchErrors=False)
-                        smi_frag = Chem.MolToSmiles(
-                            frag, isomericSmiles=True, canonical=True
-                        )
-                        uniq.add(smi_frag)
-                    except Exception:
-                        # If sanitization fails with ionic charges, try without sanitization
-                        try:
-                            smi_frag = Chem.MolToSmiles(
-                                frag, isomericSmiles=True, canonical=True
-                            )
-                            uniq.add(smi_frag)
-                        except Exception:
-                            continue  # Skip this fragment if it can't be processed
-
-            except Exception:
-                # If fragmentation fails completely, skip this cut combination
-                continue
-
-        else:
-            continue
-        break  # broke due to max_combos
-
-    return sorted(uniq)
 
 
 @tool(hidden_args=["h_smiles"])

--- a/tasks/spectra_elucidation/tests/test_scoring.py
+++ b/tasks/spectra_elucidation/tests/test_scoring.py
@@ -132,7 +132,7 @@ class TestScoreMoleculeFragments:
         prediction = []
         ground_truth = "CCO"
         score = score_molecule_fragments(prediction, ground_truth)
-        assert score == 1.0
+        assert score == 0.0
 
     def test_string_representation(self):
         """Test with string representation of a list."""

--- a/tasks/spectra_elucidation/tests/test_scoring.py
+++ b/tasks/spectra_elucidation/tests/test_scoring.py
@@ -1,0 +1,629 @@
+"""
+Tests for the scoring functions in the spectra_elucidation package.
+"""
+
+import pytest
+from rdkit import Chem
+from spectra_elucidation.score import (
+    calculate_dbe,
+    neutralize_charges,
+    parse_formula,
+    score_formula_match,
+    score_isotopic_distribution,
+    score_molecule,
+    score_molecule_fragments,
+    score_num_aromatic_carbons,
+    score_num_carbon_symmetry_classes,
+    score_num_carbonyl_groups,
+    score_num_ch3_groups,
+    score_num_hydrogen_symmetry_classes,
+    validate_dbe_consistency,
+    validate_molecular_formula,
+)
+
+
+class TestScoreMolecule:
+    """Tests for the score_molecule function."""
+
+    def test_exact_match(self):
+        """Test that identical SMILES strings return score of 1.0."""
+        prediction = "CCO"
+        ground_truth = "CCO"
+        assert score_molecule(prediction, ground_truth) == 1.0
+
+    def test_canonical_match(self):
+        """Test that different representations of the same molecule match."""
+        prediction = "C(C)O"  # Alternative representation of ethanol
+        ground_truth = "CCO"
+        assert score_molecule(prediction, ground_truth) == 1.0
+
+    def test_stereochemistry_ignored(self):
+        """Test that stereochemistry differences are ignored."""
+        prediction = "C[C@H](O)CC"  # S-stereoisomer
+        ground_truth = "C[C@@H](O)CC"  # R-stereoisomer
+        assert score_molecule(prediction, ground_truth) == 1.0
+
+    def test_no_match(self):
+        """Test that different molecules return score of 0.0."""
+        prediction = "CCO"  # Ethanol
+        ground_truth = "CC"  # Ethane
+        assert score_molecule(prediction, ground_truth) == 0.0
+
+    def test_invalid_prediction(self):
+        """Test that invalid SMILES prediction returns score of 0.0."""
+        prediction = "INVALID_SMILES"
+        ground_truth = "CCO"
+        assert score_molecule(prediction, ground_truth) == 0.0
+
+    def test_invalid_ground_truth(self):
+        """Test that invalid ground truth SMILES raises ValueError."""
+        prediction = "CCO"
+        ground_truth = "INVALID_SMILES"
+        with pytest.raises(ValueError, match="Invalid ground truth SMILES string"):
+            score_molecule(prediction, ground_truth)
+
+    def test_benzene(self):
+        """Test with aromatic molecule."""
+        prediction = "c1ccccc1"
+        ground_truth = "C1=CC=CC=C1"
+        assert score_molecule(prediction, ground_truth) == 1.0
+
+
+class TestNeutralizeCharges:
+    """Tests for the neutralize_charges function."""
+
+    def test_neutral_molecule(self):
+        """Test that neutral molecules remain unchanged."""
+        mol = Chem.MolFromSmiles("CCO")
+        result = neutralize_charges(mol)
+        assert result is not None
+        for atom in result.GetAtoms():
+            assert atom.GetFormalCharge() == 0
+
+    def test_simple_charge(self):
+        """Test neutralization of simple charged molecule."""
+        mol = Chem.MolFromSmiles("[NH4+]")
+        result = neutralize_charges(mol)
+        assert result is not None
+        # Check that charges are neutralized
+        total_charge = sum(atom.GetFormalCharge() for atom in result.GetAtoms())
+        assert total_charge == 0
+
+    def test_carboxylate_anion(self):
+        """Test neutralization of carboxylate anion."""
+        mol = Chem.MolFromSmiles("CC(=O)[O-]")
+        result = neutralize_charges(mol)
+        assert result is not None
+        total_charge = sum(atom.GetFormalCharge() for atom in result.GetAtoms())
+        assert total_charge == 0
+
+    def test_extreme_charge(self):
+        """Test neutralization of extreme charges."""
+        mol = Chem.MolFromSmiles("[O-2]")
+        result = neutralize_charges(mol)
+        assert result is not None
+        # Should attempt to neutralize even extreme charges
+
+    def test_none_input(self):
+        """Test that None input returns None."""
+        result = neutralize_charges(None)
+        assert result is None
+
+
+class TestScoreMoleculeFragments:
+    """Tests for the score_molecule_fragments function."""
+
+    def test_valid_fragments(self):
+        """Test with valid fragments that match the ground truth."""
+        prediction = ["C", "CC", "CCO"]
+        ground_truth = "CCCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 1.0
+
+    def test_invalid_fragment(self):
+        """Test with one invalid fragment in the list."""
+        prediction = ["C", "CCCCCCCC"]  # Second fragment too large
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 0.0
+
+    def test_empty_list(self):
+        """Test with empty list returns 1.0."""
+        prediction = []
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 1.0
+
+    def test_string_representation(self):
+        """Test with string representation of a list."""
+        prediction = '["C", "CC"]'
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 1.0
+
+    def test_invalid_string_format(self):
+        """Test with invalid string format returns 0.0."""
+        prediction = "not a valid list"
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 0.0
+
+    def test_non_list_input(self):
+        """Test with non-list input returns 0.0."""
+        prediction = {"C", "CC"}  # Set instead of list
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 0.0
+
+    def test_non_string_elements(self):
+        """Test with non-string elements returns 0.0."""
+        prediction = [1, 2, 3]
+        ground_truth = "CCO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score == 0.0
+
+    def test_charged_fragments(self):
+        """Test with charged fragments."""
+        prediction = ["[NH4+]", "C"]
+        ground_truth = "CN"
+        score = score_molecule_fragments(prediction, ground_truth)
+        # Should handle charged fragments through neutralization
+        assert score >= 0.0
+
+    def test_extreme_charge_fragments(self):
+        """Test with extreme charge fragments (should be lenient)."""
+        prediction = ["[O-2]", "C"]
+        ground_truth = "CO"
+        score = score_molecule_fragments(prediction, ground_truth)
+        # Extreme charge fragments are treated leniently
+        assert score >= 0.0
+
+    def test_unparseable_fragment(self):
+        """Test that unparseable fragments are skipped."""
+        prediction = ["C", "INVALID_SMILES", "CC"]
+        ground_truth = "CCC"
+        # Should skip invalid fragment and check others
+        score = score_molecule_fragments(prediction, ground_truth)
+        assert score >= 0.0
+
+
+class TestValidateMolecularFormula:
+    """Tests for the validate_molecular_formula function."""
+
+    def test_valid_formula_match(self):
+        """Test with matching molecular formula."""
+        prediction = "C2H6O"
+        ground_truth = "CCO"
+        assert validate_molecular_formula(prediction, ground_truth) is True
+
+    def test_valid_formula_no_match(self):
+        """Test with non-matching molecular formula."""
+        prediction = "C2H6"
+        ground_truth = "CCO"
+        assert validate_molecular_formula(prediction, ground_truth) is False
+
+    def test_different_order(self):
+        """Test that element order doesn't matter."""
+        prediction = "H6C2O"  # Different order
+        ground_truth = "CCO"
+        assert validate_molecular_formula(prediction, ground_truth) is True
+
+    def test_invalid_ground_truth(self):
+        """Test with invalid ground truth SMILES."""
+        prediction = "C2H6O"
+        ground_truth = "INVALID_SMILES"
+        with pytest.raises(ValueError, match="Invalid ground truth SMILES string"):
+            validate_molecular_formula(prediction, ground_truth)
+
+    def test_invalid_prediction_format(self):
+        """Test with invalid prediction format."""
+        prediction = "not_a_formula"
+        ground_truth = "CCO"
+        # Should return False or raise exception
+        assert validate_molecular_formula(prediction, ground_truth) is False
+
+
+class TestScoreFormulaMatch:
+    """Tests for the score_formula_match function."""
+
+    def test_match(self):
+        """Test with matching formula."""
+        prediction = "C2H6O"
+        ground_truth = "CCO"
+        assert score_formula_match(prediction, ground_truth) == 1.0
+
+    def test_no_match(self):
+        """Test with non-matching formula."""
+        prediction = "C2H6"
+        ground_truth = "CCO"
+        assert score_formula_match(prediction, ground_truth) == 0.0
+
+
+class TestParseFormula:
+    """Tests for the parse_formula function."""
+
+    def test_simple_formula(self):
+        """Test parsing simple molecular formula."""
+        result = parse_formula("C2H6O")
+        assert result == {"C": 2, "H": 6, "O": 1}
+
+    def test_formula_with_parentheses(self):
+        """Test parsing formula with parentheses."""
+        result = parse_formula("Ca(OH)2")
+        assert result == {"Ca": 1, "O": 2, "H": 2}
+
+    def test_formula_with_dot_adduct(self):
+        """Test parsing formula with dot notation (hydrates)."""
+        # Note: The parser doesn't handle multipliers outside parentheses like "5H2O"
+        # It treats "5H2O" as literally 5 hydrogens and 2 oxygens
+        # For proper hydrate parsing, use parentheses: CuSO4·(H2O)5
+        result = parse_formula("CuSO4·(H2O)5")
+        assert result == {"Cu": 1, "S": 1, "O": 9, "H": 10}
+
+    def test_complex_formula(self):
+        """Test parsing complex formula."""
+        result = parse_formula("C6H5(CH3)")
+        assert result == {"C": 7, "H": 8}
+
+    def test_single_element(self):
+        """Test parsing single element."""
+        result = parse_formula("O2")
+        assert result == {"O": 2}
+
+    def test_element_without_number(self):
+        """Test element without explicit number."""
+        result = parse_formula("CO")
+        assert result == {"C": 1, "O": 1}
+
+
+class TestCalculateDBE:
+    """Tests for the calculate_dbe function."""
+
+    def test_ethane(self):
+        """Test DBE calculation for ethane (saturated)."""
+        mol = Chem.MolFromSmiles("CC")
+        dbe = calculate_dbe(mol)
+        assert dbe == 0
+
+    def test_ethene(self):
+        """Test DBE calculation for ethene (one double bond)."""
+        mol = Chem.MolFromSmiles("C=C")
+        dbe = calculate_dbe(mol)
+        assert dbe == 1
+
+    def test_benzene(self):
+        """Test DBE calculation for benzene (aromatic)."""
+        mol = Chem.MolFromSmiles("c1ccccc1")
+        dbe = calculate_dbe(mol)
+        assert dbe == 4
+
+    def test_acetone(self):
+        """Test DBE calculation for acetone (carbonyl)."""
+        mol = Chem.MolFromSmiles("CC(=O)C")
+        dbe = calculate_dbe(mol)
+        assert dbe == 1
+
+    def test_with_nitrogen(self):
+        """Test DBE calculation with nitrogen."""
+        mol = Chem.MolFromSmiles("CCN")
+        dbe = calculate_dbe(mol)
+        # C=3, H=9 (including 2 on N), N=1
+        # DBE = 3 - 9/2 + 1/2 + 1 = 0
+        assert dbe == 0
+
+    def test_with_halogen(self):
+        """Test DBE calculation with halogen."""
+        mol = Chem.MolFromSmiles("CCCl")
+        dbe = calculate_dbe(mol)
+        # Halogens count like hydrogens
+        assert dbe == 0
+
+
+class TestValidateDBEConsistency:
+    """Tests for the validate_dbe_consistency function."""
+
+    def test_correct_dbe(self):
+        """Test with correct DBE value."""
+        prediction = 0
+        ground_truth = "CC"
+        assert validate_dbe_consistency(prediction, ground_truth) == 1.0
+
+    def test_incorrect_dbe(self):
+        """Test with incorrect DBE value."""
+        prediction = 5
+        ground_truth = "CC"
+        assert validate_dbe_consistency(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation of integer."""
+        prediction = "4"
+        ground_truth = "c1ccccc1"
+        assert validate_dbe_consistency(prediction, ground_truth) == 1.0
+
+    def test_invalid_string_prediction(self):
+        """Test with invalid string prediction."""
+        prediction = "not_an_integer"
+        ground_truth = "CC"
+        assert validate_dbe_consistency(prediction, ground_truth) == 0.0
+
+    def test_benzene_dbe(self):
+        """Test DBE for benzene."""
+        prediction = 4
+        ground_truth = "c1ccccc1"
+        assert validate_dbe_consistency(prediction, ground_truth) == 1.0
+
+
+class TestScoreIsotopicDistribution:
+    """Tests for the score_isotopic_distribution function."""
+
+    def test_correct_elements(self):
+        """Test with correct elements that have isotopic distribution."""
+        prediction = ["C", "O"]
+        ground_truth = "CCO"
+        assert score_isotopic_distribution(prediction, ground_truth) == 1.0
+
+    def test_incorrect_elements(self):
+        """Test with incorrect elements."""
+        prediction = ["C", "S"]
+        ground_truth = "CCO"
+        assert score_isotopic_distribution(prediction, ground_truth) == 0.0
+
+    def test_no_isotopic_elements(self):
+        """Test molecule with no relevant isotopic elements."""
+        # Methane (CH4) has Carbon which is in the isotopic elements list
+        prediction = ["C"]
+        ground_truth = "C"
+        assert score_isotopic_distribution(prediction, ground_truth) == 1.0
+
+    def test_subset_of_elements(self):
+        """Test with subset of correct elements."""
+        prediction = ["C"]
+        ground_truth = "CCO"
+        assert score_isotopic_distribution(prediction, ground_truth) == 0.0
+
+    def test_superset_of_elements(self):
+        """Test with superset of elements."""
+        prediction = ["C", "O", "N"]
+        ground_truth = "CCO"
+        assert score_isotopic_distribution(prediction, ground_truth) == 0.0
+
+
+class TestScoreNumHydrogenSymmetryClasses:
+    """Tests for the score_num_hydrogen_symmetry_classes function."""
+
+    def test_methane(self):
+        """Test with methane (all hydrogens equivalent)."""
+        prediction = 1
+        ground_truth = "C"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_ethanol(self):
+        """Test with ethanol (multiple hydrogen environments)."""
+        prediction = 3  # CH3, CH2, OH hydrogens
+        ground_truth = "CCO"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_benzene(self):
+        """Test with benzene (all hydrogens equivalent)."""
+        prediction = 1
+        ground_truth = "c1ccccc1"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_incorrect_count(self):
+        """Test with incorrect count."""
+        prediction = 5
+        ground_truth = "C"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation of integer."""
+        prediction = "1"
+        ground_truth = "C"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_invalid_string(self):
+        """Test with invalid string."""
+        prediction = "not_an_int"
+        ground_truth = "C"
+        assert score_num_hydrogen_symmetry_classes(prediction, ground_truth) == 0.0
+
+
+class TestScoreNumCarbonSymmetryClasses:
+    """Tests for the score_num_carbon_symmetry_classes function."""
+
+    def test_methane(self):
+        """Test with methane (one carbon)."""
+        prediction = 1
+        ground_truth = "C"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_ethane(self):
+        """Test with ethane (equivalent carbons)."""
+        prediction = 1
+        ground_truth = "CC"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_propane(self):
+        """Test with propane (two symmetry classes)."""
+        prediction = 2  # CH3 and CH2 carbons
+        ground_truth = "CCC"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_benzene(self):
+        """Test with benzene (all carbons equivalent)."""
+        prediction = 1
+        ground_truth = "c1ccccc1"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 1.0
+
+    def test_incorrect_count(self):
+        """Test with incorrect count."""
+        prediction = 5
+        ground_truth = "CC"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation."""
+        prediction = "1"
+        ground_truth = "C"
+        assert score_num_carbon_symmetry_classes(prediction, ground_truth) == 1.0
+
+
+class TestScoreNumAromaticCarbons:
+    """Tests for the score_num_aromatic_carbons function."""
+
+    def test_benzene(self):
+        """Test with benzene (6 aromatic carbons)."""
+        prediction = 6
+        ground_truth = "c1ccccc1"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 1.0
+
+    def test_no_aromatic_carbons(self):
+        """Test with non-aromatic molecule."""
+        prediction = 0
+        ground_truth = "CCC"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 1.0
+
+    def test_pyridine(self):
+        """Test with pyridine (5 aromatic carbons)."""
+        prediction = 5
+        ground_truth = "c1ccncc1"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 1.0
+
+    def test_naphthalene(self):
+        """Test with naphthalene (10 aromatic carbons)."""
+        prediction = 10
+        ground_truth = "c1ccc2ccccc2c1"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 1.0
+
+    def test_incorrect_count(self):
+        """Test with incorrect count."""
+        prediction = 3
+        ground_truth = "c1ccccc1"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation."""
+        prediction = "6"
+        ground_truth = "c1ccccc1"
+        assert score_num_aromatic_carbons(prediction, ground_truth) == 1.0
+
+
+class TestScoreNumCH3Groups:
+    """Tests for the score_num_ch3_groups function."""
+
+    def test_methane(self):
+        """Test with methane (not a CH3 group, no other carbons)."""
+        prediction = 0
+        ground_truth = "C"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_ethane(self):
+        """Test with ethane (two CH3 groups)."""
+        prediction = 2
+        ground_truth = "CC"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_propane(self):
+        """Test with propane (two CH3 groups)."""
+        prediction = 2
+        ground_truth = "CCC"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_isobutane(self):
+        """Test with isobutane (three CH3 groups)."""
+        prediction = 3
+        ground_truth = "CC(C)C"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_benzene(self):
+        """Test with benzene (no CH3 groups)."""
+        prediction = 0
+        ground_truth = "c1ccccc1"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_toluene(self):
+        """Test with toluene (one CH3 group)."""
+        prediction = 1
+        ground_truth = "Cc1ccccc1"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+    def test_incorrect_count(self):
+        """Test with incorrect count."""
+        prediction = 5
+        ground_truth = "CC"
+        assert score_num_ch3_groups(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation."""
+        prediction = "2"
+        ground_truth = "CC"
+        assert score_num_ch3_groups(prediction, ground_truth) == 1.0
+
+
+class TestScoreNumCarbonylGroups:
+    """Tests for the score_num_carbonyl_groups function."""
+
+    def test_acetone(self):
+        """Test with acetone (one carbonyl)."""
+        prediction = 1
+        ground_truth = "CC(=O)C"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_no_carbonyl(self):
+        """Test with molecule without carbonyl."""
+        prediction = 0
+        ground_truth = "CCO"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_acetic_acid(self):
+        """Test with acetic acid (one carbonyl)."""
+        prediction = 1
+        ground_truth = "CC(=O)O"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_oxalic_acid(self):
+        """Test with oxalic acid (two carbonyls)."""
+        prediction = 2
+        ground_truth = "C(=O)(O)C(=O)O"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_benzaldehyde(self):
+        """Test with benzaldehyde (one carbonyl)."""
+        prediction = 1
+        ground_truth = "O=Cc1ccccc1"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_tautomer_handling(self):
+        """Test that tautomers are canonicalized."""
+        # Keto-enol tautomers should be handled
+        prediction = 1
+        ground_truth = "CC(=O)C"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_incorrect_count(self):
+        """Test with incorrect count."""
+        prediction = 5
+        ground_truth = "CC(=O)C"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 0.0
+
+    def test_string_prediction(self):
+        """Test with string representation."""
+        prediction = "1"
+        ground_truth = "CC(=O)C"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_ester(self):
+        """Test with ester (one carbonyl)."""
+        prediction = 1
+        ground_truth = "CC(=O)OC"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+    def test_amide(self):
+        """Test with amide (one carbonyl)."""
+        prediction = 1
+        ground_truth = "CC(=O)N"
+        assert score_num_carbonyl_groups(prediction, ground_truth) == 1.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tasks/spectra_elucidation/tests/test_tools.py
+++ b/tasks/spectra_elucidation/tests/test_tools.py
@@ -1,0 +1,519 @@
+"""
+Tests for the tools in the spectra_elucidation package.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from spectra_elucidation.tools import (
+    carbon_nmr_spectra,
+    get_formula_from_smiles,
+    hsqc_nmr_spectra,
+    ir_spectra,
+    mass_spectrometry_spectra,
+    obtain_isomers_from_molecular_formula,
+    proton_nmr_spectra,
+    retrieve_aromatic_protons_shifts,
+    retrieve_carbon_shifts,
+    retrieve_dbe_formula,
+    retrieve_isotope_distribution,
+    retrieve_protons_shifts,
+    return_possible_fragments,
+    search_by_smiles,
+    simulate_spectra,
+    validate_smiles,
+)
+
+
+class TestGetFormulaFromSmiles:
+    """Tests for the get_formula_from_smiles tool."""
+
+    def test_valid_ethanol(self):
+        """Test formula generation for ethanol."""
+        result = get_formula_from_smiles.execute(smiles="CCO")
+        assert result == "C2H6O"
+
+    def test_valid_benzene(self):
+        """Test formula generation for benzene."""
+        result = get_formula_from_smiles.execute(smiles="C1=CC=CC=C1")
+        assert result == "C6H6"
+
+    def test_valid_acetic_acid(self):
+        """Test formula generation for acetic acid."""
+        result = get_formula_from_smiles.execute(smiles="CC(=O)O")
+        assert result == "C2H4O2"
+
+    def test_valid_glycine(self):
+        """Test formula generation for glycine."""
+        result = get_formula_from_smiles.execute(smiles="C(C(=O)O)N")
+        assert result == "C2H5NO2"
+
+    def test_invalid_smiles(self):
+        """Test with invalid SMILES string."""
+        result = get_formula_from_smiles.execute(smiles="INVALID_SMILES")
+        assert result == "Invalid SMILES string"
+
+    def test_aromatic_notation(self):
+        """Test with aromatic notation."""
+        result = get_formula_from_smiles.execute(smiles="c1ccccc1")
+        assert result == "C6H6"
+
+    def test_complex_molecule(self):
+        """Test with a more complex molecule (aspirin)."""
+        result = get_formula_from_smiles.execute(smiles="CC(=O)Oc1ccccc1C(=O)O")
+        assert result == "C9H8O4"
+
+
+class TestValidateSmiles:
+    """Tests for the validate_smiles tool."""
+
+    def test_valid_ethanol(self):
+        """Test validation of valid ethanol SMILES."""
+        result = validate_smiles.execute(smiles="CCO")
+        assert result == "True"
+
+    def test_valid_benzene(self):
+        """Test validation of valid benzene SMILES."""
+        result = validate_smiles.execute(smiles="C1=CC=CC=C1")
+        assert result == "True"
+
+    def test_valid_aromatic(self):
+        """Test validation of aromatic notation."""
+        result = validate_smiles.execute(smiles="c1ccccc1")
+        assert result == "True"
+
+    def test_invalid_smiles(self):
+        """Test validation of invalid SMILES."""
+        result = validate_smiles.execute(smiles="INVALID_SMILES")
+        assert result == "False"
+
+    def test_empty_string(self):
+        """Test validation of empty string."""
+        result = validate_smiles.execute(smiles="")
+        assert result == "True"  # Empty string creates a valid empty molecule in RDKit
+
+    def test_valid_cyclohexane(self):
+        """Test validation of cyclohexane."""
+        result = validate_smiles.execute(smiles="C1CCCCC1")
+        assert result == "True"
+
+    def test_valid_phenol(self):
+        """Test validation of phenol."""
+        result = validate_smiles.execute(smiles="C1=CC=C(C=C1)O")
+        assert result == "True"
+
+
+class TestRetrieveProtonsShifts:
+    """Tests for the retrieve_protons_shifts tool."""
+
+    def test_retrieve_protons_shifts(self):
+        """Test that retrieve_protons_shifts returns expected data structure."""
+        result = retrieve_protons_shifts.execute()
+
+        # Check that it's a string representation of a list
+        assert isinstance(result, str)
+        assert result.startswith("[")
+        assert result.endswith("]")
+
+        # Check for expected proton types in the result
+        assert "Aldehyde" in result
+        assert "Aromatic" in result
+        assert "Alkene" in result
+        assert "delta / ppm" in result
+        assert "9.5 - 10.5" in result  # Aldehyde range
+
+
+class TestRetrieveAromaticProtonsShifts:
+    """Tests for the retrieve_aromatic_protons_shifts tool."""
+
+    def test_retrieve_aromatic_protons_shifts(self):
+        """Test that retrieve_aromatic_protons_shifts returns expected data structure."""
+        result = retrieve_aromatic_protons_shifts.execute()
+
+        # Check that it's a string representation of a list
+        assert isinstance(result, str)
+        assert result.startswith("[")
+        assert result.endswith("]")
+
+        # Check for expected substituents in the result
+        assert "NO2" in result
+        assert "CHO" in result
+        assert "Ortho" in result
+        assert "Meta" in result
+        assert "Para" in result
+        assert "0.95" in result  # NO2 Ortho value
+
+
+class TestRetrieveCarbonShifts:
+    """Tests for the retrieve_carbon_shifts tool."""
+
+    def test_retrieve_carbon_shifts(self):
+        """Test that retrieve_carbon_shifts returns expected data structure."""
+        result = retrieve_carbon_shifts.execute()
+
+        # Check that it's a string representation of a list
+        assert isinstance(result, str)
+        assert result.startswith("[")
+        assert result.endswith("]")
+
+        # Check for expected functional groups in the result
+        assert "CH3-" in result
+        assert "Ketones" in result
+        assert "Aldehydes" in result
+        assert "Shift (ppm)" in result
+        assert "200-210 ppm" in result  # Ketones range
+
+
+class TestRetrieveIsotopeDistribution:
+    """Tests for the retrieve_isotope_distribution tool."""
+
+    def test_retrieve_isotope_distribution(self):
+        """Test that retrieve_isotope_distribution returns expected data structure."""
+        result = retrieve_isotope_distribution.execute()
+
+        # Check that it's a string representation of a dictionary
+        assert isinstance(result, str)
+        assert result.startswith("{")
+        assert result.endswith("}")
+
+        # Check for expected elements in the result
+        assert "Carbon" in result
+        assert "Hydrogen" in result
+        assert "Chlorine" in result
+        assert "Bromine" in result
+        assert "isotopes" in result
+        assert "m/z_peaks" in result
+
+
+class TestRetrieveDBEFormula:
+    """Tests for the retrieve_dbe_formula tool."""
+
+    def test_retrieve_dbe_formula(self):
+        """Test that retrieve_dbe_formula returns expected information."""
+        result = retrieve_dbe_formula.execute()
+
+        # Check that it's a string with the formula
+        assert isinstance(result, str)
+
+        # Check for expected content
+        assert "DBE" in result or "Double Bond Equivalent" in result
+        assert "2C + 2 + N - H - X" in result
+        assert "Benzene" in result or "C6H6" in result
+        assert "Interpretation" in result
+
+
+class TestSearchBySmiles:
+    """Tests for the search_by_smiles tool."""
+
+    @patch("spectra_elucidation.tools.vector_database_search")
+    def test_search_by_smiles_success(self, mock_vector_search):
+        """Test successful search by SMILES."""
+        # Mock the return value
+        mock_results = [
+            {
+                "entry_id": "nmrshiftdb2:123",
+                "compound_name": "Ethanol",
+                "smiles": "CCO",
+                "spectrum": {"nucleus": "13C", "shifts": [10.0, 60.0]},
+            },
+            {
+                "entry_id": "nmrshiftdb2:456",
+                "compound_name": "Ethanol derivative",
+                "smiles": "CCCO",
+                "spectrum": {"nucleus": "13C", "shifts": [10.0, 30.0, 70.0]},
+            },
+        ]
+        mock_vector_search.return_value = mock_results
+
+        result = search_by_smiles.execute(smiles="CCO", top_k=10)
+
+        # Check that the search was called with correct parameters
+        mock_vector_search.assert_called_once()
+        call_kwargs = mock_vector_search.call_args[1]
+        assert call_kwargs["query"] == "CCO"
+        assert call_kwargs["top_k"] == 10
+        assert call_kwargs["collection_name"] == "nmrshiftdb2"
+        assert call_kwargs["chemical_model"] == "ibm-research/MoLFormer-XL-both-10pct"
+
+        # Check the result - tool decorator converts to string
+        assert isinstance(result, str)
+        assert "nmrshiftdb2:123" in result
+        assert "Ethanol" in result
+
+    @patch("spectra_elucidation.tools.vector_database_search")
+    def test_search_by_smiles_with_top_k(self, mock_vector_search):
+        """Test search with custom top_k parameter."""
+        mock_vector_search.return_value = []
+
+        _result = search_by_smiles.execute(smiles="C1=CC=CC=C1", top_k=5)
+
+        call_kwargs = mock_vector_search.call_args[1]
+        assert call_kwargs["top_k"] == 5
+
+    @patch("spectra_elucidation.tools.vector_database_search")
+    def test_search_by_smiles_error(self, mock_vector_search):
+        """Test error handling in search."""
+        mock_vector_search.side_effect = Exception("Database error")
+
+        with pytest.raises(ValueError, match="Error:.*Database error"):
+            search_by_smiles.execute(smiles="CCO")
+
+
+class TestCarbonNMRSpectra:
+    """Tests for the carbon_nmr_spectra tool."""
+
+    @patch("spectra_elucidation.tools.remote_call")
+    def test_carbon_nmr_spectra_success(self, mock_remote_call):
+        """Test successful carbon NMR spectra prediction."""
+        # Mock the remote call
+        mock_function = MagicMock()
+        mock_function.return_value = "13C NMR: δC 10.0, 60.0 ppm"
+        mock_remote_call.return_value = mock_function
+
+        result = carbon_nmr_spectra.execute(h_smiles="CCO")
+
+        # Check that remote_call was called with correct parameters
+        mock_remote_call.assert_called_once_with(
+            function_name="get_c13_nmr_prediction", env_name="chemenv"
+        )
+        # Check that the returned function was called with the SMILES
+        mock_function.assert_called_once_with(smiles="CCO")
+
+        # Check the result
+        assert "13C NMR" in result
+        assert "δC" in result or "10.0" in result
+
+
+class TestProtonNMRSpectra:
+    """Tests for the proton_nmr_spectra tool."""
+
+    @patch("spectra_elucidation.tools.remote_call")
+    def test_proton_nmr_spectra_success(self, mock_remote_call):
+        """Test successful proton NMR spectra prediction."""
+        # Mock the remote call
+        mock_function = MagicMock()
+        mock_function.return_value = (
+            "1H NMR: δH 1.2 (t, 3H), 3.6 (q, 2H), 2.5 (s, 1H) ppm"
+        )
+        mock_remote_call.return_value = mock_function
+
+        result = proton_nmr_spectra.execute(h_smiles="CCO")
+
+        # Check that remote_call was called with correct parameters
+        mock_remote_call.assert_called_once_with(
+            function_name="get_h_nmr_prediction", env_name="chemenv"
+        )
+        # Check that the returned function was called with the SMILES
+        mock_function.assert_called_once_with(smiles="CCO")
+
+        # Check the result
+        assert "1H NMR" in result or "δH" in result
+
+
+class TestIRSpectra:
+    """Tests for the ir_spectra tool."""
+
+    @patch("spectra_elucidation.tools.remote_call")
+    def test_ir_spectra_success(self, mock_remote_call):
+        """Test successful IR spectra prediction."""
+        # Mock the remote call
+        mock_function = MagicMock()
+        mock_function.return_value = (
+            "IR: 3400 cm-1 (O-H stretch), 2900 cm-1 (C-H stretch)"
+        )
+        mock_remote_call.return_value = mock_function
+
+        result = ir_spectra.execute(h_smiles="CCO")
+
+        # Check that remote_call was called with correct parameters
+        mock_remote_call.assert_called_once_with(
+            function_name="get_ir_prediction", env_name="chemenv"
+        )
+        # Check that the returned function was called with the SMILES
+        mock_function.assert_called_once_with(smiles="CCO")
+
+        # Check the result
+        assert "IR" in result or "cm-1" in result or "3400" in result
+
+
+class TestHSQCNMRSpectra:
+    """Tests for the hsqc_nmr_spectra tool."""
+
+    @patch("spectra_elucidation.tools.make_api_call")
+    def test_hsqc_nmr_spectra_success(self, mock_api_call):
+        """Test successful HSQC NMR spectra prediction."""
+        # Mock the API response with correct format
+        mock_api_call.return_value = {
+            "spectra": [
+                {
+                    "info": {"pulseSequence": "hsqc"},
+                    "zones": {
+                        "values": [
+                            {
+                                "signals": [
+                                    {
+                                        "x": {"delta": 7.4, "atoms": [0, 1]},
+                                        "y": {"delta": 128.0},
+                                    },
+                                    {
+                                        "x": {"delta": 3.6, "atoms": [2, 3]},
+                                        "y": {"delta": 60.0},
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+
+        result = hsqc_nmr_spectra.execute(h_smiles="CCO")
+
+        # Check that the API was called
+        mock_api_call.assert_called_once()
+        call_args = mock_api_call.call_args[0]
+        assert (
+            call_args[0]
+            == "https://lamalab-org--nmr-prediction-api-predict-nmr.modal.run"
+        )
+        assert call_args[1]["smiles"] == "CCO"
+
+        # Check the result
+        assert isinstance(result, str)
+        assert "HSQC" in result or "delta" in result or "3.6" in result
+
+    @patch("spectra_elucidation.tools.make_api_call")
+    def test_hsqc_nmr_spectra_no_hsqc(self, mock_api_call):
+        """Test when no HSQC spectrum is found."""
+        # Mock the API response without HSQC
+        mock_api_call.return_value = {
+            "spectra": [
+                {
+                    "info": {"pulseSequence": "other"},
+                    "peaks": [],
+                }
+            ]
+        }
+
+        result = hsqc_nmr_spectra.execute(h_smiles="CCO")
+
+        assert "No HSQC spectrum found" in result
+
+
+class TestMassSpectrometrySpectra:
+    """Tests for the mass_spectrometry_spectra tool."""
+
+    @patch("spectra_elucidation.tools.make_api_call")
+    def test_mass_spectrometry_spectra_success(self, mock_api_call):
+        """Test successful mass spectrometry spectra prediction."""
+        # Mock the API response with correct format (x, y keys)
+        mock_api_call.return_value = [
+            {"x": 46.0, "y": 1000},
+            {"x": 47.0, "y": 50},
+        ]
+
+        result = mass_spectrometry_spectra.execute(h_smiles="CCO")
+
+        # Check that the API was called
+        mock_api_call.assert_called_once()
+        call_args = mock_api_call.call_args[0]
+        assert (
+            call_args[0]
+            == "https://lamalab-org--nmr-prediction-api-predict-isotopic-distribution.modal.run"
+        )
+        assert call_args[1]["smiles"] == "CCO"
+
+        # Check the result
+        assert isinstance(result, str)
+        assert "m/z" in result
+
+    def test_mass_spectrometry_invalid_smiles(self):
+        """Test with invalid SMILES string."""
+        result = mass_spectrometry_spectra.execute(h_smiles="INVALID")
+
+        assert "Invalid SMILES string" in result
+
+
+class TestObtainIsomersFromMolecularFormula:
+    """Tests for the obtain_isomers_from_molecular_formula tool."""
+
+    @patch("spectra_elucidation.tools.remote_call")
+    def test_obtain_isomers_success(self, mock_remote_call):
+        """Test successful isomer retrieval."""
+        # Mock the remote call
+        mock_function = MagicMock()
+        mock_function.return_value = ["CCO", "COC"]
+        mock_remote_call.return_value = mock_function
+
+        result = obtain_isomers_from_molecular_formula.execute(
+            molecular_formula="C2H6O", limit=10
+        )
+
+        # Check that remote_call was called with correct parameters
+        mock_remote_call.assert_called_once_with(
+            function_name="get_compound_isomers_pubchem_by_formula", env_name="chemenv"
+        )
+        # Check that the returned function was called with the formula
+        mock_function.assert_called_once_with(formula="C2H6O", limit=10)
+
+        # Check the result - tool decorator converts to string
+        assert isinstance(result, str)
+        assert "CCO" in result
+        assert "COC" in result
+
+
+class TestReturnPossibleFragments:
+    """Tests for the return_possible_fragments tool."""
+
+    def test_return_possible_fragments_valid_smiles(self):
+        """Test fragment generation for valid SMILES."""
+        # Use a simple molecule like ethanol
+        result = return_possible_fragments.execute(h_smiles="CCO")
+
+        # Check the result - tool decorator converts to string
+        assert isinstance(result, str)
+        # Should contain fragment information
+        assert "[" in result or "C" in result
+
+    def test_return_possible_fragments_complex_molecule(self):
+        """Test fragment generation for a more complex molecule."""
+        result = return_possible_fragments.execute(h_smiles="C1=CC=CC=C1")
+
+        # Check the result - tool decorator converts to string
+        assert isinstance(result, str)
+
+    def test_return_possible_fragments_invalid_smiles(self):
+        """Test with invalid SMILES string."""
+        with pytest.raises(ValueError, match="Invalid SMILES string"):
+            return_possible_fragments.execute(h_smiles="INVALID")
+
+
+class TestSimulateSpectra:
+    """Tests for the simulate_spectra tool."""
+
+    @patch("spectra_elucidation.tools.remote_call")
+    def test_simulate_spectra_success(self, mock_remote_call):
+        """Test successful spectra simulation."""
+        # Mock the remote call
+        mock_function = MagicMock()
+        mock_function.return_value = {
+            "1H NMR": "δH 1.2 (t, 3H), 3.6 (q, 2H) ppm",
+            "13C NMR": "δC 10.0, 60.0 ppm",
+            "IR": "3400 cm-1 (O-H), 2900 cm-1 (C-H)",
+        }
+        mock_remote_call.return_value = mock_function
+
+        result = simulate_spectra.execute(smiles="CCO")
+
+        # Check that remote_call was called with correct parameters
+        mock_remote_call.assert_called_once_with(
+            function_name="simulate_spectra", env_name="chemenv"
+        )
+        # Check that the returned function was called with the SMILES
+        mock_function.assert_called_once_with(smiles="CCO")
+
+        # Check the result - tool decorator converts to string
+        assert isinstance(result, str)
+        assert "1H NMR" in result
+        assert "13C NMR" in result
+        assert "IR" in result


### PR DESCRIPTION
## Summary by Sourcery

Add a new spectra_utils module by extracting reusable utilities from tools.py and refactor the tools to use it, and introduce extensive tests for both scoring logic and tool endpoints

Enhancements:
- Extract common spectra utility functions from tools.py into a dedicated spectra_utils module
- Refactor tools.py to import utility functions from spectra_utils instead of defining them inline

Tests:
- Add comprehensive unit tests for scoring functions in test_scoring.py
- Add end-to-end tests for spectra tools in test_tools.py