### PR TITLE
feat: attach logprobs in message, add to hook context

### DIFF
--- a/reports/resistor_networks/gpt_oss_single/run_react.py
+++ b/reports/resistor_networks/gpt_oss_single/run_react.py
@@ -1,0 +1,219 @@
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import litellm
+import numpy as np
+from dotenv import load_dotenv
+from loguru import logger
+
+from corral import CorralRouter, CorralRunner
+from corral.agents import ReActAgent
+from corral.agents.hooks import AgentHooks, HookPoint
+from corral.agents.hooks.core import HookContext
+from corral.report import CorralWandbLogger
+
+
+def logprobs_hook(context: HookContext) -> None:
+    """Extract, convert to dict, and save logprobs."""
+    llm_response = context.iteration_data.get("llm_response")
+    if not llm_response:
+        return
+
+    log_probs_obj = getattr(llm_response, "logprobs", None)
+    if not log_probs_obj:
+        return
+
+    # Convert Pydantic object to a standard Python Dict once
+    try:
+        if hasattr(log_probs_obj, "model_dump"):
+            lp_dict = log_probs_obj.model_dump()
+        elif hasattr(log_probs_obj, "dict"):
+            lp_dict = log_probs_obj.dict()
+        else:
+            lp_dict = log_probs_obj
+
+        # Store in metadata so other hooks can use the clean DICT
+        context.metadata["current_logprobs_dict"] = lp_dict
+
+    except Exception as e:
+        logger.error(f"Failed to convert logprobs to dict: {e}")
+        return
+
+    # Save to disk as an artifact (optional, but good for records)
+    lp_data = {
+        "id": llm_response.id,
+        "task_id": context.task_id,
+        "iteration": context.iteration,
+        "logprobs": lp_dict,
+    }
+
+    out_dir = Path("logprobs")
+    out_dir.mkdir(exist_ok=True, parents=True)
+    log_prob_hook_timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    context.metadata["logprob_hook_timestamp"] = log_prob_hook_timestamp
+    file_path = out_dir / f"{llm_response.id}_{log_prob_hook_timestamp}.json"
+
+    with file_path.open("w") as f:
+        json.dump(lp_data, f, indent=2)
+    logger.info(f"Saved logprobs to {file_path}")
+
+
+def compute_logprob_metrics(
+    logprobs: dict, log_prob_hook_timestamp
+) -> dict[str, float]:
+    if not logprobs or "content" not in logprobs:
+        return {"avg_logprob": 0, "entropy": 0, "variance": 0, "avg_top_entropy": 0}
+
+    token_logprobs = [tok["logprob"] for tok in logprobs["content"] if "logprob" in tok]
+    if not token_logprobs:
+        return {"avg_logprob": 0, "entropy": 0, "variance": 0, "avg_top_entropy": 0}
+
+    avg_logprob = np.mean(token_logprobs)
+    probs = np.exp(token_logprobs)
+    entropy = -np.sum(probs * np.log(probs + 1e-10)) / len(probs)
+    variance = np.var(token_logprobs)
+
+    # Optional: Avg entropy over top_logprobs per token (for alternative sharpness)
+    top_entropies = []
+    for tok in logprobs["content"]:
+        if "top_logprobs" in tok:
+            top_lps = [tl["logprob"] for tl in tok["top_logprobs"]]
+            if top_lps:
+                top_probs = np.exp(top_lps) / np.sum(np.exp(top_lps))  # Normalize
+                top_ent = -np.sum(top_probs * np.log(top_probs + 1e-10))
+                top_entropies.append(top_ent)
+    avg_top_entropy = np.mean(top_entropies) if top_entropies else 0
+
+    return {
+        "avg_logprob": avg_logprob,
+        "entropy": entropy,
+        "variance": variance,
+        "avg_top_entropy": avg_top_entropy,
+        "path_length": len(token_logprobs),
+        "log_prob_hook_timestamp": log_prob_hook_timestamp,
+    }
+
+
+def save_metrics_to_file(
+    task_id: str,
+    iteration: int,
+    metrics: dict[str, float],
+    log_prob_hook_timestamp=None,
+) -> None:
+    """
+    Save computed metrics to a JSON file.
+
+    Args:
+        task_id: The current task identifier
+        iteration: The iteration number
+        metrics: Dictionary of metrics (e.g., {'avg_logprob': -0.5, 'entropy': 1.2, ...})
+    """
+    out_dir = Path("metrics")
+    out_dir.mkdir(exist_ok=True, parents=True)
+
+    file_path = (
+        out_dir / f"{task_id}_iteration_{iteration}_{log_prob_hook_timestamp}.json"
+    )
+    try:
+        with file_path.open("w") as f:
+            json.dump(metrics, f, indent=2)
+        logger.info(f"Saved metrics to {file_path}")
+    except Exception as e:
+        logger.error(f"Failed to save metrics: {e}")
+
+
+def metrics_hook(context: HookContext) -> None:
+    """Compute and save metrics using the dict already in memory."""
+    # 1. Try to get the pre-converted dict from the previous hook
+    lp_dict = context.metadata.get("current_logprobs_dict")
+
+    # 2. Fallback: If logprobs_hook didn't run, try to get it from the response object
+    if not lp_dict:
+        llm_response = context.iteration_data.get("llm_response")
+        if not llm_response or not getattr(llm_response, "logprobs", None):
+            return
+
+        # (Conversion logic if needed)
+        obj = llm_response.logprobs
+        lp_dict = obj.model_dump() if hasattr(obj, "model_dump") else obj
+
+    # 3. Compute metrics using the in-memory dictionary
+    log_prob_hook_timestamp = context.metadata["logprob_hook_timestamp"]
+    metrics = compute_logprob_metrics(lp_dict, log_prob_hook_timestamp)
+
+    # Store metrics in context for logging or final report
+    context.metadata[f"iteration_{context.iteration}_metrics"] = metrics
+
+    # Save metrics to file
+    save_metrics_to_file(
+        context.task_id, context.iteration, metrics, log_prob_hook_timestamp
+    )
+
+
+def setup_litellm():
+    """Setup LiteLLM with appropriate configuration"""
+    litellm.set_verbose = True
+
+
+def run_benchmark(
+    model: str = "claude-3-5-sonnet-20241022",
+    _task_ids: list | None = None,
+    temperature: float = 0.7,
+    run_name: str = "corral_benchmark_run",
+    verbose: str = "brief",
+    hooks=None,
+):
+    """Run the benchmark with specified model and tasks"""
+
+    interface = CorralRouter(base_url="http://localhost:8000")
+    wandblogger = CorralWandbLogger(
+        project="corral_resistor_oss",
+        group="gpt_oss",
+        name=run_name,
+    )
+    agent = ReActAgent(
+        model=model,
+        logprobs=True,
+        top_logprobs=2,
+        max_iterations=20,
+        temperature=temperature,
+        api_endpoint="https://api.helmholtz-blablador.fz-juelich.de/v1",
+    )
+    runner = CorralRunner(
+        interface,
+        agent,
+        logger=wandblogger,
+    )
+
+    # Run benchmark
+    logger.info(f"Starting benchmark with model: {model}")
+    result = runner.bench(
+        trials_per_task=3,
+        task_ids=["task_0"],
+        k_values=[
+            1,
+            2,
+            3,
+        ],
+        verbose=True,
+        tool_verbosity=verbose,
+        hooks=hooks,
+    )
+    result.generate_report(f"{run_name}_try.json")
+    logger.info("Benchmark completed")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    setup_litellm()
+    os.environ["OPENAI_API_KEY"] = os.getenv("BLABLADOR_API_KEY_TEST", "")
+    verbose = "workflow"
+    hooks = AgentHooks()
+    hooks.register(HookPoint.AFTER_ITERATION, logprobs_hook)
+    hooks.register(HookPoint.AFTER_ITERATION, metrics_hook)
+
+    run_name = f"gpt_oss_120-react-resistor-{verbose}_verbosity-single"
+    model = "openai/1 - GPT-OSS-120b - an open model released by OpenAI in August 2025"
+    run_benchmark(model=model, run_name=run_name, verbose=verbose, hooks=hooks)

--- a/src/corral/agents/base_agent.py
+++ b/src/corral/agents/base_agent.py
@@ -348,6 +348,6 @@ class BaseAgent(ABC):
             interface=interface,
             messages=self.messages,
             iteration=self._current_iteration,
-            **extra_context,
+            iteration_data=extra_context,
         )
         return self.hooks.execute(hook_point, context)

--- a/src/corral/agents/hooks/intervention.py
+++ b/src/corral/agents/hooks/intervention.py
@@ -31,6 +31,10 @@ def _default_intervention(context: HookContext, intervention: str, execute_tools
 def _react_intervention(context: HookContext, intervention: str, execute_tools: bool):
     """ReAct-specific intervention with optional tool execution.
 
+    When execute_tools=True, executes in interleaved mode: each thought-action pair
+    is added as an assistant message, the tool is executed, and the observation is
+    appended before moving to the next segment.
+
     Raises:
         CriticalHookError: If execute_tools=True and tool execution fails
     """
@@ -43,21 +47,33 @@ def _react_intervention(context: HookContext, intervention: str, execute_tools: 
             flags=re.DOTALL,
         ).strip()
 
-    # Wrap in thought tags
-    if not intervention.startswith("<thought>"):
-        intervention = f"<thought>{intervention}</thought>"
+        # Wrap in thought tags
+        if not intervention.startswith("<thought>"):
+            intervention = f"<thought>{intervention}</thought>"
 
-    context.messages.append(LiteLLMMessage(role="assistant", content=intervention))
+        context.messages.append(LiteLLMMessage(role="assistant", content=intervention))
+        return
 
-    # Execute tools if requested
-    if execute_tools:
-        actions = _parse_react_actions(intervention)
+    # Interleaved execution: split intervention into thought-action segments
+    # Split on <thought> tags to get individual reasoning steps
+    segments = re.split(r"(?=<thought>)", intervention)
+
+    for _segment in segments:
+        segment = _segment.strip()
+        if not segment:
+            continue
+
+        # Append this thought-action segment as assistant message
+        context.messages.append(LiteLLMMessage(role="assistant", content=segment))
+
+        # Execute any tools in this segment
+        actions = _parse_react_actions(segment)
 
         # Check if actions were intended but couldn't be parsed
-        if not actions and "<action>" in intervention:
+        if not actions and "<action>" in segment:
             raise CriticalHookError(
                 "Failed to parse intervention actions despite execute_tools=True. "
-                "Intervention contains <action> tags but parsing failed."
+                f"Segment contains <action> tags but parsing failed: {segment[:200]}"
             )
 
         for action in actions:

--- a/src/corral/agents/react.py
+++ b/src/corral/agents/react.py
@@ -170,7 +170,8 @@ class ReActAgent(BaseAgent):
             # Execute BEFORE_ITERATION hooks
             self._execute_hooks(HookPoint.BEFORE_ITERATION, interface, task_id)
             # Create prompt and get LLM response
-            llm_response = self.get_llm_response().content
+            full_llm_response = self.get_llm_response()
+            llm_response = full_llm_response.content
 
             self.messages.append(LiteLLMMessage(role="assistant", content=llm_response))
 
@@ -217,6 +218,13 @@ class ReActAgent(BaseAgent):
                             name=action.tool_name,
                         )
                     )
+
+            self._execute_hooks(
+                HookPoint.AFTER_ITERATION,
+                interface,
+                task_id,
+                llm_response=full_llm_response,
+            )
             if final_answer_match:
                 return final_answer_match.group(1).strip()
 

--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -140,6 +140,8 @@ class ToolCallingAgent(BaseAgent):
 
             # Execute BEFORE_ITERATION hooks
             self._execute_hooks(HookPoint.BEFORE_ITERATION, interface, task_id)
+            full_llm_response = self.get_llm_response()
+            llm_response = full_llm_response.content
             try:
                 llm_response = self.get_llm_response(tools)
 
@@ -159,6 +161,12 @@ class ToolCallingAgent(BaseAgent):
 
                     final_answer_match = re.search(
                         r"Final Answer:\s*(.*)", content, re.IGNORECASE
+                    )
+                    self._execute_hooks(
+                        HookPoint.AFTER_ITERATION,
+                        interface,
+                        task_id,
+                        llm_response=full_llm_response,
                     )
                     if final_answer_match:
                         self.messages.append(

--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -140,10 +140,9 @@ class ToolCallingAgent(BaseAgent):
 
             # Execute BEFORE_ITERATION hooks
             self._execute_hooks(HookPoint.BEFORE_ITERATION, interface, task_id)
-            full_llm_response = self.get_llm_response()
-            llm_response = full_llm_response.content
             try:
-                llm_response = self.get_llm_response(tools)
+                full_llm_response = self.get_llm_response(tools)
+                llm_response = full_llm_response
 
                 content = llm_response.content
                 if content:

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -105,6 +105,8 @@ def llm_call(
             response = litellm.completion(**params)
 
         message = response.choices[0].message
+        message.logprobs = response.choices[0].logprobs
+        message.id = response.id
 
         # If message content is None, try to get reasoning_content
         if message.content is None:

--- a/src/corral/run.py
+++ b/src/corral/run.py
@@ -589,7 +589,7 @@ class CorralRunner:
 
             # Log final results
             if self.logger:
-                self.logger.log_final_results(result, k_values)
+                self.logger.log_final_results(result)
 
             # Save final checkpoint with finished suffix and remove original
             self._save_finished_checkpoint(session_id, task_results)

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -41,6 +41,7 @@ class MockLiteLLMChoice:
 
     def __init__(self):
         self.message = MockLiteLLMMessage()
+        self.logprobs = None
 
 
 class MockLiteLLMResponse:
@@ -48,6 +49,7 @@ class MockLiteLLMResponse:
 
     def __init__(self, include_usage=False):
         self.choices = [MockLiteLLMChoice()]
+        self.id = "mock_response_id"
         if include_usage:
             self.usage = MockLiteLLMUsage()
 


### PR DESCRIPTION
Attaching  logprob  object to message is not ideal. But since we only return message, this was the easiest work around.  Cleaner option would be returning response object completely I guess from `llm_call`. We can revisit this for a better design.