### PR TITLE
feat: llm response object and messages have id

### DIFF
--- a/reports/resistor_networks/gpt_oss_single/run_react.py
+++ b/reports/resistor_networks/gpt_oss_single/run_react.py
@@ -45,6 +45,7 @@ def logprobs_hook(context: HookContext) -> None:
     lp_data = {
         "id": llm_response.id,
         "task_id": context.task_id,
+        "content": llm_response.content,
         "iteration": context.iteration,
         "logprobs": lp_dict,
     }
@@ -160,7 +161,7 @@ def setup_litellm():
 def run_benchmark(
     model: str = "claude-3-5-sonnet-20241022",
     _task_ids: list | None = None,
-    temperature: float = 0.7,
+    temperature: float = 0,
     run_name: str = "corral_benchmark_run",
     verbose: str = "brief",
     hooks=None,
@@ -176,7 +177,7 @@ def run_benchmark(
     agent = ReActAgent(
         model=model,
         logprobs=True,
-        top_logprobs=2,
+        top_logprobs=20,
         max_iterations=20,
         temperature=temperature,
         api_endpoint="https://api.helmholtz-blablador.fz-juelich.de/v1",
@@ -190,13 +191,8 @@ def run_benchmark(
     # Run benchmark
     logger.info(f"Starting benchmark with model: {model}")
     result = runner.bench(
-        trials_per_task=3,
-        task_ids=["task_0"],
-        k_values=[
-            1,
-            2,
-            3,
-        ],
+        trials_per_task=5,
+        k_values=[1, 2, 3, 4, 5],
         verbose=True,
         tool_verbosity=verbose,
         hooks=hooks,
@@ -205,15 +201,30 @@ def run_benchmark(
     logger.info("Benchmark completed")
 
 
+def rename_output_dirs(verbosity: str, agent: str):
+    for dir_name in ["logprobs", "metrics"]:
+        src_dir = Path(dir_name)
+        if src_dir.exists() and src_dir.is_dir():
+            dest_dir = Path(f"{dir_name}_{verbosity}_{agent}")
+            src_dir.rename(dest_dir)
+            logger.info(f"Renamed {src_dir} to {dest_dir}")
+
+
 if __name__ == "__main__":
     load_dotenv()
     setup_litellm()
     os.environ["OPENAI_API_KEY"] = os.getenv("BLABLADOR_API_KEY_TEST", "")
-    verbose = "workflow"
-    hooks = AgentHooks()
-    hooks.register(HookPoint.AFTER_ITERATION, logprobs_hook)
-    hooks.register(HookPoint.AFTER_ITERATION, metrics_hook)
+    agent_type = "react"
+    verbosities = ["brief", "workflow", "comprehensive"]
+    for verbose in verbosities:
+        hooks = AgentHooks()
+        hooks.register(HookPoint.AFTER_ITERATION, logprobs_hook)
+        hooks.register(HookPoint.AFTER_ITERATION, metrics_hook)
 
-    run_name = f"gpt_oss_120-react-resistor-{verbose}_verbosity-single"
-    model = "openai/1 - GPT-OSS-120b - an open model released by OpenAI in August 2025"
-    run_benchmark(model=model, run_name=run_name, verbose=verbose, hooks=hooks)
+        run_name = f"gpt_oss_120-{agent_type}-resistor-{verbose}_verbosity-single"
+        model = (
+            "openai/1 - GPT-OSS-120b - an open model released by OpenAI in August 2025"
+        )
+        run_benchmark(model=model, run_name=run_name, verbose=verbose, hooks=hooks)
+        # utility function that would rename directory logprobs and metrics to include verbosity level
+        rename_output_dirs(verbose, agent_type)

--- a/src/corral/agents/base_agent.py
+++ b/src/corral/agents/base_agent.py
@@ -128,13 +128,13 @@ class BaseAgent(ABC):
             tools (dict[str, Any], optional): Optional tools/functions for function calling
 
         Returns:
-            Any: The response from the LLM
+            Any: The LLMResponse wrapper containing the message and metadata
         """
         self.messages = count_tokens_and_add(
             self.messages, self.model, self.token_usage.get("total_tokens", 0)
         )
         try:
-            response, usage_info = llm_call(
+            response = llm_call(
                 model=self.model,
                 messages=self.messages,
                 tools=tools,
@@ -144,8 +144,9 @@ class BaseAgent(ABC):
                 **self.kwargs,
             )
 
-            # Track token usage
-            self.token_usage = usage_info
+            # Track token usage from metadata
+            if response.usage:
+                self.token_usage = response.usage
 
             return response
 
@@ -287,15 +288,16 @@ class BaseAgent(ABC):
         )
 
         try:
-            answer = llm_call(
+            response = llm_call(
                 model=self.model,
                 messages=[LiteLLMMessage(role="user", content=prompt)],
                 temperature=0.0,
                 api_endpoint=self.api_endpoint,
+                return_usage=False,  # No need for usage tracking in extractor
                 **self.kwargs,
             )
 
-            return answer.content, self.messages, self.get_total_token_usage()
+            return response.content, self.messages, self.get_total_token_usage()
 
         except Exception as e:
             logger.error(f"Error extracting final answer: {e}")

--- a/src/corral/agents/llm_planner.py
+++ b/src/corral/agents/llm_planner.py
@@ -145,11 +145,12 @@ class LLMPlanner(BaseAgent):
             )
 
         for _i in range(self.max_iterations):
-            plan = self.get_llm_response().content
+            response = self.get_llm_response()
+            plan = response.content
 
             self.messages.append(
                 LiteLLMMessage(
-                    role="assistant", content=plan, name="high-level-planner"
+                    role="assistant", content=plan, name="high-level-planner", id=response.id
                 )
             )
             if plan is None:

--- a/src/corral/agents/llm_planner.py
+++ b/src/corral/agents/llm_planner.py
@@ -150,7 +150,10 @@ class LLMPlanner(BaseAgent):
 
             self.messages.append(
                 LiteLLMMessage(
-                    role="assistant", content=plan, name="high-level-planner", id=response.id
+                    role="assistant",
+                    content=plan,
+                    name="high-level-planner",
+                    id=response.id,
                 )
             )
             if plan is None:

--- a/src/corral/agents/react.py
+++ b/src/corral/agents/react.py
@@ -173,7 +173,11 @@ class ReActAgent(BaseAgent):
             full_llm_response = self.get_llm_response()
             llm_response = full_llm_response.content
 
-            self.messages.append(LiteLLMMessage(role="assistant", content=llm_response))
+            self.messages.append(
+                LiteLLMMessage(
+                    role="assistant", content=llm_response, id=full_llm_response.id
+                )
+            )
 
             # Parse response
             thoughts, actions = self.parse_llm_response(llm_response)

--- a/src/corral/agents/reflection.py
+++ b/src/corral/agents/reflection.py
@@ -227,7 +227,8 @@ class ReflectionModule:
                 **self.kwargs,
             )
 
-            reflection_text = response.content.strip()
+            content = response.content or ""
+            reflection_text = content.strip()
             logger.debug(f"Generated reflection: {reflection_text}")
 
             # Extract usage from metadata

--- a/src/corral/agents/reflection.py
+++ b/src/corral/agents/reflection.py
@@ -218,7 +218,7 @@ class ReflectionModule:
             )
 
         try:
-            response, usage_info = llm_call(
+            response = llm_call(
                 model=self.model,
                 messages=messages,
                 temperature=self.temperature,
@@ -230,7 +230,12 @@ class ReflectionModule:
             reflection_text = response.content.strip()
             logger.debug(f"Generated reflection: {reflection_text}")
 
-            # usage_info is a dict with prompt_tokens, completion_tokens, total_tokens
+            # Extract usage from metadata
+            usage_info = response.usage or {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+            }
             return reflection_text, usage_info
 
         except Exception as e:

--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -174,7 +174,9 @@ class ToolCallingAgent(BaseAgent):
                     if final_answer_match:
                         self.messages.append(
                             LiteLLMMessage(
-                                role="assistant", content=content, id=full_llm_response.id
+                                role="assistant",
+                                content=content,
+                                id=full_llm_response.id,
                             )
                         )
                         return final_answer_match.group(1).strip()

--- a/src/corral/agents/tool_calling.py
+++ b/src/corral/agents/tool_calling.py
@@ -154,7 +154,11 @@ class ToolCallingAgent(BaseAgent):
                         if surrender_match:
                             logger.info(f"Agent retiring from task {task_id}")
                             self.messages.append(
-                                LiteLLMMessage(role="assistant", content=content)
+                                LiteLLMMessage(
+                                    role="assistant",
+                                    content=content,
+                                    id=full_llm_response.id,
+                                )
                             )
                             return "GIVE UP"
 
@@ -169,13 +173,18 @@ class ToolCallingAgent(BaseAgent):
                     )
                     if final_answer_match:
                         self.messages.append(
-                            LiteLLMMessage(role="assistant", content=content)
+                            LiteLLMMessage(
+                                role="assistant", content=content, id=full_llm_response.id
+                            )
                         )
                         return final_answer_match.group(1).strip()
 
                 tool_calls = llm_response.tool_calls
                 if tool_calls:
-                    self.messages.append(llm_response)
+                    # Append the underlying message object with id from metadata
+                    message_with_id = llm_response.message
+                    message_with_id.id = full_llm_response.id
+                    self.messages.append(message_with_id)
 
                     for called_tool in tool_calls:
                         # Initialize variables for error handling
@@ -222,7 +231,11 @@ class ToolCallingAgent(BaseAgent):
                         )
                 else:
                     self.messages.append(
-                        LiteLLMMessage(role="assistant", content=llm_response.content)
+                        LiteLLMMessage(
+                            role="assistant",
+                            content=llm_response.content,
+                            id=full_llm_response.id,
+                        )
                     )
             except Exception as e:
                 # Append error message but continue with the next iteration

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -35,18 +35,86 @@ TYPE_MAPPING = {
     "dict": "object",
 }
 
-
 def before_sleep_loguru(retry_state):
     logger.info(
         f"Retrying: {retry_state.attempt_number}, wait: {retry_state.next_action.sleep} seconds"
     )
 
 
+class LLMResponseMetadata(TypedDict, total=False):
+    """Metadata for LLM responses"""
+
+    id: str | None
+    logprobs: Any | None
+    usage: dict[str, int] | None
+
+
+
+class LLMResponse:
+    """
+    Wrapper for LLM responses with optional metadata.
+
+    This class wraps the raw LLM message response and includes optional metadata
+    like logprobs, message ID, and token usage.
+
+    Args:
+        message (Message): The raw LLM message response
+        metadata (LLMResponseMetadata | None): Optional metadata including logprobs, id, and usage
+
+    Properties:
+        content: Access message content
+        role: Access message role
+        tool_calls: Access tool calls (if any)
+        logprobs: Access logprobs from metadata
+        id: Access message ID from metadata
+        usage: Access token usage from metadata
+    """
+
+    def __init__(
+        self, message: Message, metadata: LLMResponseMetadata | None = None
+    ) -> None:
+        self.message = message
+        self.metadata = metadata or LLMResponseMetadata()
+
+    @property
+    def content(self) -> str | None:
+        """Get the message content"""
+        return self.message.content
+
+    @property
+    def role(self) -> str:
+        """Get the message role"""
+        return self.message.role
+
+    @property
+    def tool_calls(self) -> Any:
+        """Get tool calls from the message"""
+        return getattr(self.message, "tool_calls", None)
+
+    # Access to metadata
+    @property
+    def logprobs(self) -> Any:
+        """Get logprobs from metadata"""
+        return self.metadata.get("logprobs")
+
+    @property
+    def id(self) -> str | None:
+        """Get message ID from metadata"""
+        return self.metadata.get("id")
+
+    @property
+    def usage(self) -> dict[str, int] | None:
+        """Get token usage from metadata"""
+        return self.metadata.get("usage")
+    
+    
+
 class LiteLLMMessage(TypedDict, total=False):
     role: str
     content: str | list
     tool_call_id: str | None
     name: str | None
+    id: str | None 
 
 
 @retry(
@@ -62,9 +130,9 @@ def llm_call(
     temperature: float,
     tools: list[dict[str, Any]] | None = None,
     api_endpoint: str | None = None,
-    return_usage: bool = False,
+    return_usage: bool = True,
     **kwargs,
-) -> Message | tuple[Message, dict[str, Any]]:
+) -> LLMResponse:
     """
     Call LiteLLM API with or without tools based on parameters
 
@@ -74,11 +142,12 @@ def llm_call(
         temperature (float): The temperature to use.
         tools (dict[str, Any], optional): The tools to use. If provided, will use tool calling.
         api_endpoint (str, optional): The API endpoint to use. When using VLLM.
-        return_usage (bool, optional): If True, returns tuple of (message, usage_info). Defaults to False.
+        return_usage (bool, optional): If True, includes token usage in metadata. Defaults to True.
         **kwargs: Additional keyword arguments to pass to the LiteLLM API.
+            If 'logprobs' is True in kwargs, logprobs will be included in response metadata.
 
     Returns:
-        Message | tuple[Message, dict]: The response from the LiteLLM API, optionally with usage info.
+        LLMResponse: Wrapper containing the message and optional metadata (id, logprobs if requested, usage).
     """
     try:
         params = {
@@ -105,8 +174,6 @@ def llm_call(
             response = litellm.completion(**params)
 
         message = response.choices[0].message
-        message.logprobs = response.choices[0].logprobs
-        message.id = response.id
 
         # If message content is None, try to get reasoning_content
         if message.content is None:
@@ -115,9 +182,16 @@ def llm_call(
                 # Ensure reasoning_content is a string
                 message.content = str(reasoning_content) if reasoning_content else None
 
+        metadata = LLMResponseMetadata()
+        metadata["id"] = response.id
+
+        # Include logprobs if requested via kwargs
+        if kwargs.get("logprobs"):
+            metadata["logprobs"] = response.choices[0].logprobs
+
+        # Include usage info if requested
         if return_usage:
-            # Extract usage information from the response
-            usage_info = {
+            metadata["usage"] = {
                 "prompt_tokens": getattr(response.usage, "prompt_tokens", 0)
                 if response.usage
                 else 0,
@@ -128,9 +202,8 @@ def llm_call(
                 if response.usage
                 else 0,
             }
-            return message, usage_info
 
-        return message
+        return LLMResponse(message, metadata)
 
     except Exception as e:
         raise e

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -409,6 +409,8 @@ def serialize_messages(messages: list[LiteLLMMessage]) -> list[dict]:
         else:
             message_dict = {"role": msg.role, "content": msg.content}
 
+            if hasattr(msg, "id") and msg.id:
+                message_dict["id"] = msg.id
             if hasattr(msg, "tool_call_id") and msg.tool_call_id:
                 message_dict["tool_call_id"] = msg.tool_call_id
             if hasattr(msg, "name") and msg.name:

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -35,6 +35,7 @@ TYPE_MAPPING = {
     "dict": "object",
 }
 
+
 def before_sleep_loguru(retry_state):
     logger.info(
         f"Retrying: {retry_state.attempt_number}, wait: {retry_state.next_action.sleep} seconds"
@@ -47,7 +48,6 @@ class LLMResponseMetadata(TypedDict, total=False):
     id: str | None
     logprobs: Any | None
     usage: dict[str, int] | None
-
 
 
 class LLMResponse:
@@ -106,15 +106,14 @@ class LLMResponse:
     def usage(self) -> dict[str, int] | None:
         """Get token usage from metadata"""
         return self.metadata.get("usage")
-    
-    
+
 
 class LiteLLMMessage(TypedDict, total=False):
     role: str
     content: str | list
     tool_call_id: str | None
     name: str | None
-    id: str | None 
+    id: str | None
 
 
 @retry(

--- a/tests/agents/conftest.py
+++ b/tests/agents/conftest.py
@@ -34,13 +34,14 @@ class MockBenchmarkInterface:
                 {
                     "name": "test_tool",
                     "description": "A test tool",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "query": {"type": "string", "description": "Test query"}
-                        },
-                        "required": ["query"],
-                    },
+                    "arguments": [
+                        {
+                            "name": "query",
+                            "type": "str",
+                            "description": "Test query",
+                            "required": True,
+                        }
+                    ],
                 }
             ]
         }
@@ -91,12 +92,57 @@ class MockBenchmarkInterface:
         ), f"{method_name} was called when it shouldn't have been"
 
 
-class MockLLMResponse:
-    """Mock LLM response for testing."""
+class MockMessage:
+    """Mock message class that mimics litellm's Message object."""
 
     def __init__(self, content: str | None = None, tool_calls: list | None = None):
         self.content = content
         self.tool_calls = tool_calls or []
+        self.role = "assistant"
+        self.id = None  # Can be set later
+
+
+class MockLLMResponse:
+    """Mock LLM response for testing, matching the LLMResponse interface."""
+
+    def __init__(
+        self,
+        content: str | None = None,
+        tool_calls: list | None = None,
+        usage: dict | None = None,
+        response_id: str | None = None,
+        logprobs: Any | None = None,
+    ):
+        # Create underlying message object
+        self.message = MockMessage(content=content, tool_calls=tool_calls or [])
+        self._usage = usage
+        self._id = response_id
+        self._logprobs = logprobs
+
+    @property
+    def content(self) -> str | None:
+        """Get message content"""
+        return self.message.content
+
+    @property
+    def tool_calls(self) -> list:
+        """Get tool calls from the message"""
+        return self.message.tool_calls
+
+    @property
+    def usage(self) -> dict | None:
+        """Get token usage from metadata"""
+        return self._usage
+
+    @property
+    def id(self) -> str | None:
+        """Get message ID from metadata"""
+        return self._id
+
+    @property
+    def logprobs(self) -> Any:
+        """Get logprobs from metadata"""
+        return self._logprobs
 
 
 class MockToolCall:

--- a/tests/agents/test_base_agent.py
+++ b/tests/agents/test_base_agent.py
@@ -194,15 +194,15 @@ def test_base_agent_kwargs_passed_through():
 
 def test_base_agent_get_llm_response_success(monkeypatch, concrete_agent):
     """Test successful LLM response."""
-    mock_response = MockLLMResponse("Test response")
     mock_usage = {
         "prompt_tokens": 100,
         "completion_tokens": 50,
         "total_tokens": 150,
     }
+    mock_response = MockLLMResponse("Test response", usage=mock_usage)
 
     def mock_llm_call(*args, **kwargs):
-        return (mock_response, mock_usage)
+        return mock_response
 
     monkeypatch.setattr("corral.agents.base_agent.llm_call", mock_llm_call)
 
@@ -218,15 +218,15 @@ def test_base_agent_get_llm_response_success(monkeypatch, concrete_agent):
 
 def test_get_llm_response_with_tools(monkeypatch, concrete_agent):
     """Test LLM response with tools."""
-    mock_response = MockLLMResponse()
     mock_usage = {
         "prompt_tokens": 100,
         "completion_tokens": 50,
         "total_tokens": 150,
     }
+    mock_response = MockLLMResponse(usage=mock_usage)
 
     def mock_llm_call(*args, **kwargs):
-        return (mock_response, mock_usage)
+        return mock_response
 
     monkeypatch.setattr("corral.agents.base_agent.llm_call", mock_llm_call)
 

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -10,6 +10,7 @@ from corral.agents.utils import (
     RETRY_EXCEPTIONS,
     TYPE_MAPPING,
     LiteLLMMessage,
+    LLMResponse,
     _parse_argument_string_to_dict,
     before_sleep_loguru,
     convert_dict_arg,
@@ -105,12 +106,14 @@ class MockSerializableMessage:
         tool_calls=None,
         tool_call_id=None,
         name=None,
+        msg_id=None,
     ):
         self.role = role
         self.content = content
         self.tool_calls = tool_calls or []
         self.tool_call_id = tool_call_id
         self.name = name
+        self.id = msg_id
 
 
 def test_type_mapping_functionality():
@@ -170,9 +173,11 @@ def test_litellm_message_structure():
         "content": "Hi there",
         "tool_call_id": "call_123",
         "name": "assistant",
+        "id": "msg_123",
     }
     assert msg2["tool_call_id"] == "call_123"
     assert msg2["name"] == "assistant"
+    assert msg2["id"] == "msg_123"
 
 
 def test_llm_call_basic(monkeypatch):
@@ -183,7 +188,11 @@ def test_llm_call_basic(monkeypatch):
 
     result = llm_call(model="gpt-3.5-turbo", messages=messages, temperature=0.7)
 
-    assert result == mock_response.choices[0].message
+    # Check that result is LLMResponse wrapper
+    assert isinstance(result, LLMResponse)
+    assert result.message == mock_response.choices[0].message
+    assert result.content == "This is a response"
+    assert result.id == "mock_response_id"  # ID should always be included
     mock_litellm.completion.assert_called_once_with(
         model="gpt-3.5-turbo",
         messages=messages,
@@ -203,7 +212,10 @@ def test_llm_call_with_tools(monkeypatch):
         model="gpt-3.5-turbo", messages=messages, temperature=0.7, tools=tools
     )
 
-    assert result == mock_response.choices[0].message
+    # Check that result is LLMResponse wrapper
+    assert isinstance(result, LLMResponse)
+    assert result.message == mock_response.choices[0].message
+    assert result.id == "mock_response_id"
     mock_litellm.completion.assert_called_once_with(
         model="gpt-3.5-turbo",
         messages=messages,
@@ -224,7 +236,10 @@ def test_llm_call_anthropic_model(monkeypatch):
         model="anthropic/claude-3-sonnet", messages=messages, temperature=0.7
     )
 
-    assert result == mock_response.choices[0].message
+    # Check that result is LLMResponse wrapper
+    assert isinstance(result, LLMResponse)
+    assert result.message == mock_response.choices[0].message
+    assert result.id == "mock_response_id"
     mock_litellm.completion.assert_called_once_with(
         model="anthropic/claude-3-sonnet",
         messages=messages,
@@ -244,14 +259,51 @@ def test_llm_call_with_usage_info(monkeypatch):
         model="gpt-3.5-turbo", messages=messages, temperature=0.7, return_usage=True
     )
 
-    assert isinstance(result, tuple)
-    message, usage_info = result
-    assert message == mock_response.choices[0].message
-    assert usage_info == {
+    # Check that result is LLMResponse wrapper with usage metadata
+    assert isinstance(result, LLMResponse)
+    assert result.message == mock_response.choices[0].message
+    assert result.id == "mock_response_id"
+    assert result.usage == {
         "prompt_tokens": 10,
         "completion_tokens": 20,
         "total_tokens": 30,
     }
+
+
+def test_llm_call_with_logprobs(monkeypatch):
+    """Test llm_call with logprobs=True in kwargs."""
+    mock_litellm, mock_response = setup_mock_litellm(monkeypatch)
+    # Set logprobs on the mock response
+    mock_response.choices[0].logprobs = {"token": "test", "logprob": -0.5}
+
+    messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
+
+    result = llm_call(
+        model="gpt-3.5-turbo",
+        messages=messages,
+        temperature=0.7,
+        logprobs=True,
+        top_logprobs=20,
+    )
+
+    # Check that result includes logprobs when requested
+    assert isinstance(result, LLMResponse)
+    assert result.logprobs == {"token": "test", "logprob": -0.5}
+    assert result.id == "mock_response_id"
+
+
+def test_llm_call_without_logprobs(monkeypatch):
+    """Test llm_call without logprobs (default behavior)."""
+    mock_litellm, mock_response = setup_mock_litellm(monkeypatch)
+
+    messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
+
+    result = llm_call(model="gpt-3.5-turbo", messages=messages, temperature=0.7)
+
+    # Check that result does NOT include logprobs when not requested
+    assert isinstance(result, LLMResponse)
+    assert result.logprobs is None
+    assert result.id == "mock_response_id"
 
 
 def test_llm_call_exception_handling(monkeypatch):
@@ -761,6 +813,21 @@ def test_serialize_messages_with_tool_calls():
     assert message["tool_calls"][0]["id"] == "call_123"
     assert message["tool_calls"][0]["function"]["name"] == "test_function"
     assert message["tool_calls"][0]["function"]["arguments"] == '{"arg": "value"}'
+
+
+def test_serialize_messages_with_id():
+    """Test serializing messages with id field."""
+    mock_message = MockSerializableMessage(
+        role="assistant", content="Hi there", id="msg_12345"
+    )
+
+    result = serialize_messages([mock_message])
+
+    assert len(result) == 1
+    message = result[0]
+    assert message["role"] == "assistant"
+    assert message["content"] == "Hi there"
+    assert message["id"] == "msg_12345"
 
 
 def test_save_agent_messages_basic():

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -51,8 +51,8 @@ class MockLiteLLMResponse:
     def __init__(self, include_usage=False):
         self.choices = [MockLiteLLMChoice()]
         self.id = "mock_response_id"
-        if include_usage:
-            self.usage = MockLiteLLMUsage()
+        # Always have usage attribute, but set to None if not included
+        self.usage = MockLiteLLMUsage() if include_usage else None
 
 
 class MockLiteLLMUsage:
@@ -818,7 +818,7 @@ def test_serialize_messages_with_tool_calls():
 def test_serialize_messages_with_id():
     """Test serializing messages with id field."""
     mock_message = MockSerializableMessage(
-        role="assistant", content="Hi there", id="msg_12345"
+        role="assistant", content="Hi there", msg_id="msg_12345"
     )
 
     result = serialize_messages([mock_message])

--- a/uv.lock
+++ b/uv.lock
@@ -715,6 +715,7 @@ docs = [
     { name = "mkdocs-gen-files" },
     { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-terminal" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pillow" },
 ]
@@ -722,8 +723,6 @@ docs = [
 [package.dev-dependencies]
 dev = [
     { name = "isort" },
-    { name = "mkdocs-terminal" },
-    { name = "mkdocstrings" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "streamlit" },
@@ -733,6 +732,7 @@ docs = [
     { name = "mkdocs-gen-files" },
     { name = "mkdocs-literate-nav" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-terminal" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pillow" },
 ]
@@ -753,6 +753,7 @@ requires-dist = [
     { name = "mkdocs-gen-files", marker = "extra == 'docs'", specifier = ">=0.5.0" },
     { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = ">=0.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
+    { name = "mkdocs-terminal", marker = "extra == 'docs'", specifier = ">=4.7.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
     { name = "modal", specifier = ">=1.1.4" },
     { name = "more-itertools", specifier = ">=10.7.0" },
@@ -784,8 +785,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "isort", specifier = ">=6.0.1" },
-    { name = "mkdocs-terminal", specifier = ">=4.7.0" },
-    { name = "mkdocstrings", specifier = ">=0.29.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.4" },
     { name = "streamlit", specifier = ">=1.46.1" },
@@ -795,6 +794,8 @@ docs = [
     { name = "mkdocs-gen-files", specifier = ">=0.5.0" },
     { name = "mkdocs-literate-nav", specifier = ">=0.6.0" },
     { name = "mkdocs-material", specifier = ">=9.4.0" },
+    { name = "mkdocs-terminal", specifier = ">=4.7.0" },
+    { name = "mkdocstrings", specifier = ">=0.29.1" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.22.0" },
     { name = "pillow", specifier = ">=10.0.0" },
 ]


### PR DESCRIPTION
## Summary by Sourcery

Introduce a structured LLMResponse wrapper that carries message metadata (IDs, logprobs, and token usage) and propagate stable message IDs through agents, serialization, and benchmarking utilities.

New Features:
- Add LLMResponse wrapper object encapsulating raw LLM messages along with optional metadata such as ID, logprobs, and usage.

Enhancements:
- Change llm_call to always return an LLMResponse, capturing response IDs, optional logprobs, and usage metadata based on call parameters.
- Extend LiteLLMMessage and message serialization to support message IDs and ensure agents (tool-calling, ReAct, planner, base agent, reflection) propagate and store assistant message IDs for later use.
- Adjust benchmarking script to log logprobs with associated content, tweak sampling/benchmark parameters, support multiple verbosity levels, and rename output directories to encode verbosity and agent type.
- Update test tooling configuration to use an argument-list style schema for tools instead of a JSON-schema-like parameters object.
- Refine base agent and reflection logic to read token usage from LLMResponse metadata instead of tuple returns and to handle missing content safely.

Tests:
- Update and extend unit tests and mocks to use the LLMResponse wrapper, cover logprobs and usage metadata handling, and validate serialization of message IDs.