### PR TITLE
fix: deterministic path resolution in scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Corral is a benchmarking framework for evaluating AI agents on science tasks (materials science, chemistry, etc.). It provides standardized environments, tools, and metrics to test agent performance across diverse scientific challenges.
+
+## Common Commands
+
+```bash
+# Install dependencies
+uv sync --all-extras --dev
+
+# Run all tests
+uv run pytest tests
+
+# Run a single test file
+uv run pytest tests/agents/test_react.py
+
+# Run a specific test
+uv run pytest tests/agents/test_react.py::test_name -v
+
+# Lint
+ruff check .
+
+# Format
+ruff format .
+
+# Install a task environment for development
+cd tasks/<task_name> && uv pip install -e .
+
+# Run task-specific tests
+cd tasks/<task_name> && CORRAL_WORK_DIR=$(mktemp -d) uv run python -m pytest tests -v --rootdir=.
+
+# Pre-commit (includes ruff, formatting, commitizen)
+pre-commit run --all-files
+```
+
+## Architecture
+
+### Core flow: Runner → Router → Server → Environment
+
+- **CorralRunner** (`src/corral/run.py`) — Orchestrates benchmark execution: manages trials, checkpointing (auto-save/resume), budget tracking, and W&B logging.
+- **CorralRouter** (`src/corral/router/routes.py`) — HTTP client that agents use to interact with the benchmark server (list tasks, get tools, execute tools, submit answers).
+- **Benchmark Server** (`src/corral/backend/server.py`) — FastAPI server created via `create_benchmark_server()` that hosts task environments.
+- **Environment** (`src/corral/backend/env.py`) — Abstract base class for task environments. Each task implements this with its own tools and scoring. `TaskState` tracks trial state (messages, tool calls, score).
+
+### Agent types (`src/corral/agents/`)
+
+All extend `BaseAgent` (`base_agent.py`). Four strategies:
+- **ReActAgent** — Reasoning + Acting loop
+- **ToolCallingAgent** — Native LLM function calling
+- **LLMPlanner** — Hierarchical planning
+- **ReflexionAgent** — Self-reflection and learning from mistakes
+
+Agents use LiteLLM for unified LLM API access. Agent utilities (token counting, LLM calls) are in `agents/utils.py`.
+
+### Tool system (`src/corral/backend/tool.py`)
+
+Tools are defined with the `@tool` decorator. Supports MCP (Model Context Protocol) conversion and Modal cloud execution (`@modal_tool`). Tool verbosity levels (FULL, BRIEF, MINIMAL, NONE) control description detail via `src/corral/router/verbosity.py`.
+
+### Metrics and reporting (`src/corral/report/`)
+
+Registry-based metric system. `BenchmarkResult` aggregates results; `TaskTrialResult` holds individual trial data. Default metrics include average score, success rate, and pass@k. Custom metrics register via `MetricRegistry`.
+
+### Task environments (`tasks/`)
+
+Each task is its own Python package with `pyproject.toml`, `env.py`, `tools.py`, `tests/`, and `config/`. Tasks include: samplemath, spectra_elucidation, corral_md (LAMMPS MD), catalyst, afm, ml, retrosynthesis, resistor_network, wetlab.
+
+## Key Conventions
+
+- **Commits**: Uses commitizen for conventional commits (enforced by pre-commit hook on commit-msg stage). Install hooks with: `pre-commit install --hook-type commit-msg --hook-type pre-push`
+- **Imports**: `src` layout — the package is `corral` under `src/corral/`. pytest is configured with `pythonpath = "src"`.
+- **Ruff**: Extensive rule set enabled (see `pyproject.toml`). Notable ignores: E501 (line length), PLR (design pylint). Print statements (T20) and unused variables (F841) are unfixable (won't be auto-removed). `__init__.py` files allow unused imports (F401). Tests ignore ANN, ARG, D, E402, PTH, S101.
+- **Pre-commit excludes**: Ruff, formatting, and whitespace hooks exclude `tasks/` (except `tasks/*/src/`) and `reports/afm/`.
+- **Git LFS**: Used for large files (e.g., MD environment data).
+- **Environment variable**: `CORRAL_WORK_DIR` — needed by some task tests for working directory.

--- a/src/corral/backend/env.py
+++ b/src/corral/backend/env.py
@@ -1,5 +1,6 @@
 import inspect
 import time
+import uuid
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -41,6 +42,8 @@ class TaskState:
     submitted_answer: str | None = None
     feedback: str | None = None
     surrendered: bool = False
+    workspace_id: str | None = None
+    workspace_path: str | None = None
     env_start_time: datetime = field(
         default_factory=lambda: datetime.now(tz=timezone.utc)
     )
@@ -81,6 +84,15 @@ class Environment(ABC):
         self.trial_states: dict[str, TaskState] = {}
         self.trial_counter = -1
         self.fs_manager = fs_manager
+        self.current_workspace_id: str | None = None
+        if base_work_dir:
+            from corral.utils.workspace_registry import WorkspaceRegistry
+
+            self.workspace_registry: WorkspaceRegistry | None = WorkspaceRegistry(
+                base_work_dir
+            )
+        else:
+            self.workspace_registry = None
         self.reset_state()
 
     def save_current_state(self) -> TaskState:
@@ -100,25 +112,47 @@ class Environment(ABC):
                 self.state.env_end_time = datetime.now(tz=timezone.utc)
             archived_snapshot = self.save_current_state()
             self.trial_states[self.state.trial_id] = archived_snapshot
+            # Mark previous workspace as completed in registry
+            if self.workspace_registry and self.current_workspace_id:
+                self.workspace_registry.update_status(
+                    self.current_workspace_id,
+                    "completed",
+                    completed_at=datetime.now(tz=timezone.utc).isoformat(),
+                )
 
         self.trial_counter += 1
         new_trial_id = str(self.trial_counter)
 
         if self.base_work_dir:
-            self.current_work_dir = self._create_trial_workspace(new_trial_id)
+            self.current_workspace_id = str(uuid.uuid4())
+            self.current_work_dir = self._create_trial_workspace(
+                new_trial_id, self.current_workspace_id
+            )
+            if self.workspace_registry:
+                self.workspace_registry.register_workspace(
+                    self.task_id,
+                    new_trial_id,
+                    self.current_workspace_id,
+                    self.current_work_dir,
+                )
         else:
             self.current_work_dir = None
+            self.current_workspace_id = None
 
         self.state = TaskState(
             task_id=self.task_id,
             trial_id=new_trial_id,
             task_prompt=self.get_task_prompt(),
+            workspace_id=self.current_workspace_id,
+            workspace_path=self.current_work_dir,
         )
         return self.state.trial_id
 
-    def _create_trial_workspace(self, trial_id: str) -> str:
-        """Create workspace directory for this trial"""
-        workspace = Path(self.base_work_dir) / f"{self.task_id}_trial_{trial_id}"
+    def _create_trial_workspace(self, trial_id: str, workspace_id: str) -> str:
+        """Create workspace directory for this trial with UUID identifier."""
+        workspace = (
+            Path(self.base_work_dir) / f"{self.task_id}_trial_{trial_id}_{workspace_id}"
+        )
         logger.info(f"Creating workspace: {workspace}")
         if self.fs_manager:
             self.fs_manager.mkdir(str(workspace), create_parents=True)
@@ -381,6 +415,8 @@ class Environment(ABC):
             "submitted_answer": self.state.submitted_answer,
             "surrendered": self.state.surrendered,
             "tool_statistics": self._get_complete_tool_statistics(),
+            "workspace_id": self.state.workspace_id,
+            "workspace_path": self.state.workspace_path,
         }
 
         return {"trial_id": self.state.trial_id, "state": state_data}

--- a/src/corral/backend/schema.py
+++ b/src/corral/backend/schema.py
@@ -56,6 +56,7 @@ class TrialCompletionResponse(BaseModel):
     state: dict[str, Any]
     trial_id: str
     surrendered: bool = False
+    workspace_id: str | None = None
 
 
 class ToLatexRequest(BaseModel):

--- a/src/corral/backend/server.py
+++ b/src/corral/backend/server.py
@@ -47,6 +47,7 @@ def _finalize_trial(
         state=completed_trial["state"],
         trial_id=finished_trial_id,
         surrendered=surrendered,
+        workspace_id=completed_trial["state"].get("workspace_id"),
     )
 
 
@@ -331,6 +332,52 @@ def create_benchmark_server(environments: dict[str, Environment]) -> FastAPI:
             raise HTTPException(
                 status_code=500, detail=f"Failed to generate LaTeX: {e!s}"
             ) from e
+
+    @app.get("/tasks/{task_id}/workspaces")
+    def get_workspaces(task_id: str):
+        """Get all workspace entries for a task from the registry."""
+        if task_id not in environments:
+            raise HTTPException(status_code=404, detail="Task not found")
+        env = environments[task_id]
+        if env.workspace_registry:
+            entries = env.workspace_registry.get_workspaces(task_id=task_id)
+            return {
+                "workspaces": [
+                    {
+                        "workspace_id": e.workspace_id,
+                        "task_id": e.task_id,
+                        "trial_id": e.trial_id,
+                        "path": e.path,
+                        "status": e.status,
+                        "created_at": e.created_at,
+                        "completed_at": e.completed_at,
+                    }
+                    for e in entries
+                ]
+            }
+        return {"workspaces": []}
+
+    @app.get("/tasks/{task_id}/workspaces/{workspace_id}")
+    def get_workspace(task_id: str, workspace_id: str):
+        """Look up a specific workspace by UUID."""
+        if task_id not in environments:
+            raise HTTPException(status_code=404, detail="Task not found")
+        env = environments[task_id]
+        if env.workspace_registry:
+            entry = env.workspace_registry.get_by_id(workspace_id)
+            if entry:
+                return {
+                    "workspace": {
+                        "workspace_id": entry.workspace_id,
+                        "task_id": entry.task_id,
+                        "trial_id": entry.trial_id,
+                        "path": entry.path,
+                        "status": entry.status,
+                        "created_at": entry.created_at,
+                        "completed_at": entry.completed_at,
+                    }
+                }
+        raise HTTPException(status_code=404, detail="Workspace not found")
 
     return app
 

--- a/src/corral/report/results.py
+++ b/src/corral/report/results.py
@@ -22,6 +22,8 @@ class TaskTrialResult:
     token_usage: dict[str, int] | None = None
     error_message: str | None = None
     surrendered: bool = False
+    workspace_id: str | None = None
+    workspace_path: str | None = None
 
     @property
     def success(self) -> bool:

--- a/src/corral/router/routes.py
+++ b/src/corral/router/routes.py
@@ -32,6 +32,8 @@ def _parse_trial_completion(task_id: str, response_data: dict) -> TaskTrialResul
         tool_statistics=completion.state["tool_statistics"],
         surrendered=completion.surrendered,
         duration=completion.state.get("duration"),
+        workspace_id=completion.workspace_id,
+        workspace_path=completion.state.get("workspace_path"),
     )
 
 

--- a/src/corral/utils/io_tools.py
+++ b/src/corral/utils/io_tools.py
@@ -249,7 +249,8 @@ class WriteFileTool(Tool):
 
     def execute(self, **kwargs) -> str:
         self.fs_manager.write_file(kwargs["path"], kwargs["content"])
-        return f"Successfully wrote to {kwargs['path']}"
+        resolved = self.fs_manager._resolve_path(kwargs["path"])
+        return f"Successfully wrote to {resolved}"
 
 
 class FileInfoTool(Tool):
@@ -345,7 +346,8 @@ class CopyFileTool(Tool):
     def execute(self, **kwargs) -> str:
         try:
             self.fs_manager.copy_file(kwargs["source"], kwargs["destination"])
-            return f"Copied {kwargs['source']} to {kwargs['destination']}"
+            resolved_dest = self.fs_manager._resolve_path(kwargs["destination"])
+            return f"Copied {kwargs['source']} to {resolved_dest}"
         except Exception as e:
             return f"Error: {e}"
 

--- a/src/corral/utils/io_tools.py
+++ b/src/corral/utils/io_tools.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import json
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import fsspec
 import modal
 
 from corral.backend.schema import ToolArgument
 from corral.backend.tool import Tool
+
+if TYPE_CHECKING:
+    from corral.utils.workspace_registry import WorkspaceRegistry
 
 
 class FSManager:
@@ -19,12 +25,16 @@ class FSManager:
         protocol: str = "file",
         base_path: str = "./",
         app: str | None = None,
+        registry: WorkspaceRegistry | None = None,
+        workspace_id: str | None = None,
         **kwargs,
     ):
         self.protocol = protocol
         self.base_path = Path(base_path) if base_path else None
         self.fs = fsspec.filesystem(protocol, **kwargs)
         self.app = app
+        self.registry = registry
+        self.workspace_id = workspace_id
 
     def _resolve_path(self, path: str) -> str:
         """Resolve a relative path against the base_path"""
@@ -37,19 +47,6 @@ class FSManager:
         # Relative path - resolve against base_path
         resolved = self.base_path / path_obj
         return str(resolved)
-
-    def _resolve_path(self, path: str) -> str:
-        """Resolve a relative path against the base_path"""
-        if self.base_path is None:
-            return path
-
-        path_obj = Path(path)
-        if path_obj.is_absolute():
-            return str(path_obj)
-        else:
-            # Relative path - resolve against base_path
-            resolved = self.base_path / path_obj
-            return str(resolved)
 
     def list_files(self, path: str, recursive: bool = False) -> list[str]:
         """List files in a directory"""
@@ -88,6 +85,11 @@ class FSManager:
 
                 with self.fs.open(resolved_path, "w") as f:
                     f.write(content)
+
+            # Track file in registry
+            if self.registry and self.workspace_id:
+                filename = Path(resolved_path).name
+                self.registry.register_file(self.workspace_id, filename, resolved_path)
         except Exception as e:
             raise RuntimeError(f"Error writing file {path}: {e}") from e
 

--- a/src/corral/utils/task_group.py
+++ b/src/corral/utils/task_group.py
@@ -14,7 +14,6 @@ from corral.utils.io_tools import (
     ReadFileTool,
     WriteFileTool,
 )
-from corral.utils.tool_helpers import smart_resolve_path
 
 
 class TaskGroupEnvironment(Environment):
@@ -75,12 +74,14 @@ class TaskGroupEnvironment(Environment):
             self.add_tool(tool)
 
     def _setup_file_tools(self):
-        """Setup file tools with global workspace scope for cross-trial access."""
-        if self.base_work_dir:
-            logger.info(f"Setting up FSManager with base_path: {self.base_work_dir}")
-            # FSManager scoped to base_work_dir (global) for cross-trial file access
+        """Setup file tools scoped to the current trial workspace."""
+        current_work_dir = self.get_current_work_dir()
+        if current_work_dir:
+            logger.info(f"Setting up FSManager with base_path: {current_work_dir}")
+            # FSManager scoped to current_work_dir (per-trial) so relative paths
+            # from hidden_args tools resolve correctly within the trial workspace
             fsmanager_kwargs = {
-                "base_path": self.base_work_dir,
+                "base_path": current_work_dir,
                 "registry": self.workspace_registry,
                 "workspace_id": self.current_workspace_id,
             }
@@ -103,11 +104,9 @@ class TaskGroupEnvironment(Environment):
             # Add static extra tools
             file_tools.update(self._extra_file_tools)
             self.tools.update(file_tools)
-            logger.info(
-                f"File tools setup complete for workspace: {self.base_work_dir}"
-            )
+            logger.info(f"File tools setup complete for workspace: {current_work_dir}")
         else:
-            logger.warning("No base_work_dir set, skipping file tools setup")
+            logger.warning("No work_dir set, skipping file tools setup")
 
     def reset_state(self) -> str:
         """Reset state and update file tools for new workspace"""
@@ -168,43 +167,30 @@ Required submission format:
         return prompt
 
     def score(self) -> float:
-        """Score the submitted answer"""
-        logger.info(f"🔥 SCORE METHOD CALLED FOR {self.task_id}")
+        """Score the submitted answer.
+
+        Resolves relative paths against the current workspace so agents
+        don't need to submit absolute paths.  No searching or heuristics.
+        """
         if not self.state.submitted_answer:
             logger.warning(f"No submission found for task {self.task_id}")
             return 0.0
 
         try:
-            # Get and log the raw submission
-            answer_value = self.state.submitted_answer.strip()
-            logger.info(f"Raw submission for {self.task_id}: {answer_value!r}")
+            answer = self.state.submitted_answer.strip()
 
-            # Detect if it's JSON and skip path resolution
-            if answer_value.startswith("{") and answer_value.endswith("}"):
-                logger.info("Detected JSON submission, skipping path resolution")
-                resolved_answer = answer_value  # Use as-is
-            else:
-                logger.info("Non-JSON submission, using path resolution")
-                resolved_answer = smart_resolve_path(
-                    answer_value, registry=self.workspace_registry
-                )
+            # Resolve relative file paths against the workspace.
+            # Absolute paths and non-path data (JSON strings) pass through.
+            if not answer.startswith(("{", "[")) and not Path(answer).is_absolute():
+                work_dir = self.get_current_work_dir()
+                if work_dir:
+                    answer = str(Path(work_dir) / answer)
 
-            logger.info(f"Resolved answer for {self.task_id}: {resolved_answer!r}")
-            # Call the scoring function with the raw answer
-            score = self.current_task.scoring_fn(resolved_answer)
-
-            # Store result in task group
-            self.task_group.store_result(
-                self.task_id, {"answer": resolved_answer}, score
-            )
+            score = self.current_task.scoring_fn(answer)
+            self.task_group.store_result(self.task_id, {"answer": answer}, score)
             logger.info(f"Task {self.task_id} scored: {score}")
-
             return score
 
         except Exception as e:
-            logger.error(
-                f"Error scoring submission for task {self.task_id}: {e!s}",
-                exc_info=True,
-            )
-            logger.error(f"Submission was: {self.state.submitted_answer!r}")
+            logger.error(f"Error scoring task {self.task_id}: {e!s}", exc_info=True)
             return 0.0

--- a/src/corral/utils/task_group.py
+++ b/src/corral/utils/task_group.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from loguru import logger
 
 from corral.backend.env import Environment
@@ -23,23 +25,41 @@ class TaskGroupEnvironment(Environment):
         task_id: str,
         task_group: TaskGroup,
         subtask_specific_tools: dict[str, Tool],
-        base_work_dir: str,
+        base_work_dir: str | Path,
         taskgroup_common_tools: dict[str, Tool] | None = None,
+        hidden_args_keys: list[str] | None = None,
+        fsmanager_app: str | None = None,
+        extra_file_tools: dict[str, Tool] | None = None,
+        extra_fsmanager_tool_classes: dict[str, type] | None = None,
     ):
         self.task_group = task_group
         self.subtask_specific_tools = subtask_specific_tools
         self.taskgroup_common_tools = taskgroup_common_tools or {}
+        self._hidden_args_keys = hidden_args_keys or []
+        self._fsmanager_app = fsmanager_app
+        self._extra_file_tools = extra_file_tools or {}
+        self._extra_fsmanager_tool_classes = extra_fsmanager_tool_classes or {}
 
         if task_id not in task_group.tasks:
             raise ValueError(f"Task {task_id} not found in task group")
 
         self.current_task = task_group.tasks[task_id]
 
+        # Initialize hidden_args before super().__init__ which calls reset_state
+        self.hidden_args: dict[str, str] = {}
+
         super().__init__(f"{task_id}", base_work_dir=base_work_dir)
+
+        self._update_hidden_args()
 
         # Add tools
         self._add_task_tools()
         self._setup_file_tools()
+
+    def _update_hidden_args(self):
+        """Update hidden_args with current workspace values."""
+        if "work_dir" in self._hidden_args_keys:
+            self.hidden_args["work_dir"] = self.get_current_work_dir()
 
     def _add_task_tools(self):
         """Add required tools for the task"""
@@ -55,34 +75,44 @@ class TaskGroupEnvironment(Environment):
             self.add_tool(tool)
 
     def _setup_file_tools(self):
-        """Setup file tools for current workspace"""
-        if self.current_work_dir:
-            logger.info(
-                f"DEBUG: Setting up FSManager with base_path: {self.current_work_dir}"
-            )
-            # Create new FSManager for current workspace
-            fs_manager = FSManager("file", base_path=self.current_work_dir)
+        """Setup file tools with global workspace scope for cross-trial access."""
+        if self.base_work_dir:
+            logger.info(f"Setting up FSManager with base_path: {self.base_work_dir}")
+            # FSManager scoped to base_work_dir (global) for cross-trial file access
+            fsmanager_kwargs = {
+                "base_path": self.base_work_dir,
+                "registry": self.workspace_registry,
+                "workspace_id": self.current_workspace_id,
+            }
+            if self._fsmanager_app:
+                fsmanager_kwargs["app"] = self._fsmanager_app
+            fs_manager = FSManager("file", **fsmanager_kwargs)
 
             # Add/update file tools
-            self.tools.update(
-                {
-                    "list_files": ListFilesTool(fs_manager),
-                    "read_file": ReadFileTool(fs_manager),
-                    "write_file": WriteFileTool(fs_manager),
-                    "file_info": FileInfoTool(fs_manager),
-                    "cat_files": CatFilesTool(fs_manager),
-                    "copy_file": CopyFileTool(fs_manager),
-                }
-            )
+            file_tools = {
+                "list_files": ListFilesTool(fs_manager),
+                "read_file": ReadFileTool(fs_manager),
+                "write_file": WriteFileTool(fs_manager),
+                "file_info": FileInfoTool(fs_manager),
+                "cat_files": CatFilesTool(fs_manager),
+                "copy_file": CopyFileTool(fs_manager),
+            }
+            # Add tools that need FSManager instance
+            for name, cls in self._extra_fsmanager_tool_classes.items():
+                file_tools[name] = cls(fs_manager)
+            # Add static extra tools
+            file_tools.update(self._extra_file_tools)
+            self.tools.update(file_tools)
             logger.info(
-                f"DEBUG: File tools setup complete for workspace: {self.current_work_dir}"
+                f"File tools setup complete for workspace: {self.base_work_dir}"
             )
         else:
-            logger.warning("DEBUG: No current_work_dir set, skipping file tools setup")
+            logger.warning("No base_work_dir set, skipping file tools setup")
 
     def reset_state(self) -> str:
         """Reset state and update file tools for new workspace"""
         trial_id = super().reset_state()
+        self._update_hidden_args()
         # Recreate file tools for new workspace
         self._setup_file_tools()
         return trial_id
@@ -118,7 +148,9 @@ Required submission format:
 
         # Add workspace info
         if self.current_work_dir:
-            prompt += "\nIMPORTANT: You have access to filesystem tools. All files will be saved in your isolated workspace.\n"
+            rel_workspace = Path(self.current_work_dir).name
+            prompt += f"\nIMPORTANT: You have access to filesystem tools. Your workspace directory is: {rel_workspace}/\n"
+            prompt += "Write your output files to this directory.\n"
 
         # Add note about dependencies
         if self.current_task.input_from_tasks:
@@ -153,7 +185,9 @@ Required submission format:
                 resolved_answer = answer_value  # Use as-is
             else:
                 logger.info("Non-JSON submission, using path resolution")
-                resolved_answer = smart_resolve_path(answer_value)
+                resolved_answer = smart_resolve_path(
+                    answer_value, registry=self.workspace_registry
+                )
 
             logger.info(f"Resolved answer for {self.task_id}: {resolved_answer!r}")
             # Call the scoring function with the raw answer

--- a/src/corral/utils/tool_helpers.py
+++ b/src/corral/utils/tool_helpers.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import requests
@@ -13,6 +15,9 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+
+if TYPE_CHECKING:
+    from corral.utils.workspace_registry import WorkspaceRegistry
 
 
 def extract_path_from_answer(answer: str) -> str:
@@ -49,15 +54,25 @@ def extract_path_from_answer(answer: str) -> str:
     return answer
 
 
-def find_file_by_name(filename: str, base_dir: str | None = None) -> str:
-    """Find file by name in workspace"""
+def find_file_by_name(
+    filename: str,
+    base_dir: str | None = None,
+    registry: WorkspaceRegistry | None = None,
+) -> str:
+    """Find file by name. Uses registry if available, falls back to rglob search."""
+    # Try registry-backed lookup first
+    if registry:
+        result = registry.find_file(filename)
+        if result:
+            return result
+
+    # Fallback: recursive filesystem search
     if not base_dir:
         base_dir = os.environ.get("CORRAL_WORK_DIR", "")
 
     if not base_dir or not Path(base_dir).exists():
         return filename
 
-    # Search for the file recursively
     base_path = Path(base_dir)
     matches = list(base_path.rglob(filename))
 
@@ -68,14 +83,22 @@ def find_file_by_name(filename: str, base_dir: str | None = None) -> str:
     return filename
 
 
-def smart_resolve_path(input_path: str) -> str:
-    """Resolve path intelligently - use absolute path if exists, search only as fallback"""
+def smart_resolve_path(
+    input_path: str,
+    registry: WorkspaceRegistry | None = None,
+) -> str:
+    """Resolve path intelligently - use absolute path if exists, search only as fallback.
+
+    When a registry is provided, file lookup uses the SQLite registry
+    instead of recursive filesystem search.
+    """
     extracted_path = extract_path_from_answer(input_path)
 
     if Path(extracted_path).exists():
         return extracted_path  # Use the extracted path directly
-    else:
-        return find_file_by_name(Path(extracted_path).name)  # Search as fallback
+    return find_file_by_name(
+        Path(extracted_path).name, registry=registry
+    )  # Search as fallback
 
 
 @retry(

--- a/src/corral/utils/workspace_registry.py
+++ b/src/corral/utils/workspace_registry.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from loguru import logger
+
+
+@dataclass
+class WorkspaceEntry:
+    """Metadata for a trial workspace directory."""
+
+    workspace_id: str  # UUID4
+    task_id: str
+    trial_id: str  # logical "0", "1", etc.
+    path: str  # full workspace path
+    status: str  # "active" | "completed" | "abandoned"
+    created_at: str  # ISO 8601
+    completed_at: str | None = None
+
+
+class WorkspaceRegistry:
+    """SQLite-backed registry tracking trial workspaces and their files.
+
+    This is internal infrastructure — agents never interact with it.
+    The registry enables:
+    - UUID-based workspace identification
+    - Persistent tracking of workspaces across sessions
+    - Registry-backed file lookup (replacing fragile rglob search)
+    - Post-hoc analysis and debugging of benchmark runs
+    """
+
+    DB_FILENAME = ".corral_registry.db"
+
+    def __init__(self, base_work_dir: str):
+        self.base_work_dir = base_work_dir
+        self.db_path = str(Path(base_work_dir) / self.DB_FILENAME)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Create tables if they don't exist."""
+        Path(self.base_work_dir).mkdir(parents=True, exist_ok=True)
+        with self._get_conn() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS workspaces (
+                    workspace_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    trial_id TEXT NOT NULL,
+                    path TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'active',
+                    created_at TEXT NOT NULL,
+                    completed_at TEXT
+                );
+
+                CREATE TABLE IF NOT EXISTS files (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    workspace_id TEXT NOT NULL REFERENCES workspaces(workspace_id),
+                    filename TEXT NOT NULL,
+                    rel_path TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_files_filename ON files(filename);
+                CREATE INDEX IF NOT EXISTS idx_files_workspace ON files(workspace_id);
+                CREATE INDEX IF NOT EXISTS idx_workspaces_task ON workspaces(task_id);
+                """
+            )
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Open a connection. Use as context manager for auto-commit."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def register_workspace(
+        self,
+        task_id: str,
+        trial_id: str,
+        workspace_id: str,
+        path: str,
+    ) -> WorkspaceEntry:
+        """Register a new workspace in the registry."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+        entry = WorkspaceEntry(
+            workspace_id=workspace_id,
+            task_id=task_id,
+            trial_id=trial_id,
+            path=path,
+            status="active",
+            created_at=now,
+        )
+        with self._get_conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO workspaces (workspace_id, task_id, trial_id, path, status, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.workspace_id,
+                    entry.task_id,
+                    entry.trial_id,
+                    entry.path,
+                    entry.status,
+                    entry.created_at,
+                ),
+            )
+        logger.debug(
+            f"Registered workspace {workspace_id} for {task_id} trial {trial_id}"
+        )
+        return entry
+
+    def update_status(
+        self,
+        workspace_id: str,
+        status: str,
+        completed_at: str | None = None,
+    ) -> None:
+        """Update workspace status (e.g., active -> completed)."""
+        with self._get_conn() as conn:
+            conn.execute(
+                """
+                UPDATE workspaces SET status = ?, completed_at = ?
+                WHERE workspace_id = ?
+                """,
+                (status, completed_at, workspace_id),
+            )
+
+    def register_file(
+        self,
+        workspace_id: str,
+        filename: str,
+        rel_path: str,
+    ) -> None:
+        """Track a file created in a workspace."""
+        now = datetime.now(tz=timezone.utc).isoformat()
+        with self._get_conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO files (workspace_id, filename, rel_path, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (workspace_id, filename, rel_path, now),
+            )
+
+    def find_file(
+        self,
+        filename: str,
+        task_id: str | None = None,
+    ) -> str | None:
+        """Find a file by name, optionally scoped to a task.
+
+        Returns the full path of the most recently registered match, or None.
+        """
+        with self._get_conn() as conn:
+            if task_id:
+                row = conn.execute(
+                    """
+                    SELECT f.rel_path FROM files f
+                    JOIN workspaces w ON f.workspace_id = w.workspace_id
+                    WHERE f.filename = ? AND w.task_id = ?
+                    ORDER BY f.created_at DESC
+                    LIMIT 1
+                    """,
+                    (filename, task_id),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """
+                    SELECT rel_path FROM files
+                    WHERE filename = ?
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                    """,
+                    (filename,),
+                ).fetchone()
+        if row:
+            return row["rel_path"]
+        return None
+
+    def get_workspaces(
+        self,
+        task_id: str | None = None,
+        status: str | None = None,
+    ) -> list[WorkspaceEntry]:
+        """Query workspaces, optionally filtered by task_id and/or status."""
+        query = "SELECT * FROM workspaces WHERE 1=1"
+        params: list[str] = []
+        if task_id:
+            query += " AND task_id = ?"
+            params.append(task_id)
+        if status:
+            query += " AND status = ?"
+            params.append(status)
+        query += " ORDER BY created_at"
+
+        with self._get_conn() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [
+            WorkspaceEntry(
+                workspace_id=r["workspace_id"],
+                task_id=r["task_id"],
+                trial_id=r["trial_id"],
+                path=r["path"],
+                status=r["status"],
+                created_at=r["created_at"],
+                completed_at=r["completed_at"],
+            )
+            for r in rows
+        ]
+
+    def get_by_id(self, workspace_id: str) -> WorkspaceEntry | None:
+        """Look up a workspace by its UUID."""
+        with self._get_conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM workspaces WHERE workspace_id = ?",
+                (workspace_id,),
+            ).fetchone()
+        if not row:
+            return None
+        return WorkspaceEntry(
+            workspace_id=row["workspace_id"],
+            task_id=row["task_id"],
+            trial_id=row["trial_id"],
+            path=row["path"],
+            status=row["status"],
+            created_at=row["created_at"],
+            completed_at=row["completed_at"],
+        )

--- a/tasks/afm/src/env.py
+++ b/tasks/afm/src/env.py
@@ -171,13 +171,16 @@ class AFMEnvironment(Environment):
             self.add_tool(tool)
 
     def _setup_file_tools(self):
-        """Setup file tools for current workspace"""
-        if self.current_work_dir:
-            logger.info(
-                f"DEBUG: Setting up FSManager with base_path: {self.current_work_dir}"
+        """Setup file tools with global workspace scope for cross-trial access."""
+        if self.base_work_dir:
+            logger.info(f"Setting up FSManager with base_path: {self.base_work_dir}")
+            # FSManager scoped to base_work_dir (global) for cross-trial file access
+            fs_manager = FSManager(
+                "file",
+                base_path=self.base_work_dir,
+                registry=self.workspace_registry,
+                workspace_id=self.current_workspace_id,
             )
-            # Create new FSManager for current workspace
-            fs_manager = FSManager("file", base_path=self.current_work_dir)
 
             # Add/update file tools
             self.tools.update(
@@ -191,10 +194,10 @@ class AFMEnvironment(Environment):
                 }
             )
             logger.info(
-                f"DEBUG: File tools setup complete for workspace: {self.current_work_dir}"
+                f"File tools setup complete for workspace: {self.base_work_dir}"
             )
         else:
-            logger.warning("DEBUG: No current_work_dir set, skipping file tools setup")
+            logger.warning("No base_work_dir set, skipping file tools setup")
 
     def reset_params(self) -> None:
         if pythoncom:

--- a/tasks/catalyst/src/catalyst/score.py
+++ b/tasks/catalyst/src/catalyst/score.py
@@ -8,45 +8,12 @@ from pathlib import Path
 from loguru import logger
 from pymatgen.core import Structure
 
-from corral.utils.tool_helpers import smart_resolve_path
-
 # Generate a random 4-letter unique identifier
 uid = "".join(secrets.choice(string.ascii_lowercase) for _ in range(6))
 
 # Set the path. If CORRAL_WORK_DIR is missing, it uses the relative path with the UID.
 BASE_WORK_DIR = os.environ.get("CORRAL_WORK_DIR", f"../CORRAL_WORK_DIR/catalyst_{uid}")
 os.environ["CORRAL_WORK_DIR"] = BASE_WORK_DIR
-
-
-def resolve_path(path_or_str: str) -> str:
-    """
-    Resolves a path that might be relative to the base work directory.
-    Also cleans up common input format issues.
-    """
-    # Handle various input issues
-    if isinstance(path_or_str, str):
-        # Remove "answer:" prefix if present
-        if path_or_str.startswith("answer:"):
-            path_or_str = path_or_str.replace("answer:", "", 1).strip()
-
-        # Replace escaped quotes that might come from JSON strings
-        path_or_str = path_or_str.replace('\\"', '"').replace("\\'", "'")
-
-    try:
-        # If it's an absolute path or already exists, return as is
-        if Path(path_or_str).is_absolute() or Path(path_or_str).exists():
-            return path_or_str
-
-        # Try to resolve against base directory
-        full_path = Path(BASE_WORK_DIR) / path_or_str
-        if full_path.exists():
-            return str(full_path)
-
-        # If we can't resolve it, return the original
-        return path_or_str
-    except Exception:
-        # If there's any error treating it as a path, return the original
-        return path_or_str
 
 
 def check_valid_json_file(json_path: str) -> float:
@@ -107,19 +74,15 @@ def check_slabs_json(slabs_json: str) -> float:
     the CIF string for one of the slabs. Accepts either a path to a JSON file or a raw JSON string.
     """
     try:
-        logger.info(f"check_slabs_json: input={slabs_json!r}")
+        # Path already resolved by TaskGroupEnvironment.score()
+        resolved_input = slabs_json.strip()
 
-        # Try to resolve as path
-        resolved_input = smart_resolve_path(slabs_json)
-        logger.info(f"check_slabs_json: resolved={resolved_input!r}")
-
-        # Try loading from file if it's a valid path
+        # Load from file or parse as JSON string
         json_data = None
-        if Path(resolved_input).exists():
+        if not resolved_input.startswith("{") and Path(resolved_input).exists():
             with Path(resolved_input).open() as f:
                 json_data = json.load(f)
         else:
-            # Try parsing as raw JSON string (try original first, then resolved)
             try:
                 json_data = json.loads(slabs_json)
             except json.JSONDecodeError:
@@ -327,14 +290,11 @@ def check_adsorption_sites(sites_json_or_path: str) -> float:
             logger.warning("Empty input provided to check_adsorption_sites")
             return 0.0
 
-        logger.info(f"check_adsorption_sites: input={sites_json_or_path!r}")
-
-        # Try to resolve as path
-        resolved_input = smart_resolve_path(sites_json_or_path.strip())
-        logger.info(f"check_adsorption_sites: resolved={resolved_input!r}")
+        # Path already resolved by TaskGroupEnvironment.score()
+        resolved_input = sites_json_or_path.strip()
 
         # Try to load from file first
-        if Path(resolved_input).is_file():
+        if not resolved_input.startswith("{") and Path(resolved_input).is_file():
             with Path(resolved_input).open() as f:
                 json_content = f.read()
         else:

--- a/tasks/catalyst/tests/test_environment_integration.py
+++ b/tasks/catalyst/tests/test_environment_integration.py
@@ -273,7 +273,7 @@ loop_
     def test_scoring_with_valid_submission(
         self, task_group, mock_tools, temp_workspace
     ):
-        """Test scoring with a valid file submission."""
+        """Test scoring with a valid file submission (relative path resolved against workspace)."""
         with patch.dict(os.environ, {"CORRAL_WORK_DIR": str(temp_workspace)}):
             env = TaskGroupEnvironment(
                 task_id="task1",
@@ -282,20 +282,24 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
-            # Simulate submitting a valid CIF file path
+            # Copy test file to trial workspace (where FSManager would put it)
+            workspace = Path(env.get_current_work_dir())
+            src_file = temp_workspace / "bulk_structure.cif"
+            dst_file = workspace / "bulk_structure.cif"
+            dst_file.write_text(src_file.read_text())
+
+            # Submit relative path — score() resolves against workspace
             env.state.submitted_answer = "bulk_structure.cif"
             score = env.score()
 
             assert score == 1.0
             assert "task1" in task_group.results
-            assert task_group.results["task1"]["answer"] == str(
-                temp_workspace / "bulk_structure.cif"
-            )
+            assert task_group.results["task1"]["answer"] == str(dst_file)
 
-    def test_scoring_with_markdown_formatted_submission(
+    def test_scoring_with_absolute_path_from_write_file(
         self, task_group, mock_tools, temp_workspace
     ):
-        """Test scoring with markdown-formatted submission."""
+        """Test scoring with absolute path (as returned by WriteFileTool)."""
         with patch.dict(os.environ, {"CORRAL_WORK_DIR": str(temp_workspace)}):
             env = TaskGroupEnvironment(
                 task_id="task1",
@@ -304,19 +308,23 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
-            # Submit with markdown formatting
-            env.state.submitted_answer = "The structure file is `bulk_structure.cif`."
+            # Copy test file to trial workspace
+            workspace = Path(env.get_current_work_dir())
+            src_file = temp_workspace / "bulk_structure.cif"
+            dst_file = workspace / "bulk_structure.cif"
+            dst_file.write_text(src_file.read_text())
+
+            # Submit absolute path (as WriteFileTool now returns)
+            env.state.submitted_answer = str(dst_file)
             score = env.score()
 
             assert score == 1.0
-            assert task_group.results["task1"]["answer"] == str(
-                temp_workspace / "bulk_structure.cif"
-            )
+            assert task_group.results["task1"]["answer"] == str(dst_file)
 
-    def test_scoring_with_quoted_submission(
+    def test_scoring_with_relative_filename(
         self, task_group, mock_tools, temp_workspace
     ):
-        """Test scoring with quoted submission."""
+        """Test scoring with relative filename resolved against workspace."""
         with patch.dict(os.environ, {"CORRAL_WORK_DIR": str(temp_workspace)}):
             env = TaskGroupEnvironment(
                 task_id="task3",
@@ -325,14 +333,18 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
-            # Submit with quotes
-            env.state.submitted_answer = 'The JSON file is "valid_data.json".'
+            # Copy test file to trial workspace
+            workspace = Path(env.get_current_work_dir())
+            src_file = temp_workspace / "valid_data.json"
+            dst_file = workspace / "valid_data.json"
+            dst_file.write_text(src_file.read_text())
+
+            # Submit relative filename — resolved against workspace
+            env.state.submitted_answer = "valid_data.json"
             score = env.score()
 
             assert score == 1.0
-            assert task_group.results["task3"]["answer"] == str(
-                temp_workspace / "valid_data.json"
-            )
+            assert task_group.results["task3"]["answer"] == str(dst_file)
 
     def test_scoring_with_absolute_path_submission(
         self, task_group, mock_tools, temp_workspace
@@ -346,7 +358,7 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
-            # Submit absolute path
+            # Submit absolute path (file exists in temp_workspace)
             abs_path = str(temp_workspace / "bulk_structure.cif")
             env.state.submitted_answer = abs_path
             score = env.score()
@@ -381,6 +393,10 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
+            # Copy invalid file to trial workspace
+            workspace = Path(env.get_current_work_dir())
+            (workspace / "invalid.txt").write_text("This is not JSON")
+
             env.state.submitted_answer = "invalid.txt"  # Not JSON
             score = env.score()
 
@@ -389,7 +405,7 @@ loop_
     def test_scoring_with_subdirectory_file(
         self, task_group, mock_tools, temp_workspace
     ):
-        """Test scoring when file is in subdirectory."""
+        """Test scoring with relative subdirectory path resolved against workspace."""
         with patch.dict(os.environ, {"CORRAL_WORK_DIR": str(temp_workspace)}):
             env = TaskGroupEnvironment(
                 task_id="task1",
@@ -398,13 +414,20 @@ loop_
                 base_work_dir=str(temp_workspace),
             )
 
-            # Submit filename that exists in subdirectory
-            env.state.submitted_answer = "output.cif"
+            # Copy test file to trial workspace subdirectory
+            workspace = Path(env.get_current_work_dir())
+            results_dir = workspace / "results"
+            results_dir.mkdir(parents=True, exist_ok=True)
+            src_file = temp_workspace / "results" / "output.cif"
+            dst_file = results_dir / "output.cif"
+            dst_file.write_text(src_file.read_text())
+
+            # Submit relative path — resolved against workspace
+            env.state.submitted_answer = "results/output.cif"
             score = env.score()
 
             assert score == 1.0
-            # Should resolve to the file in the subdirectory
-            assert "results/output.cif" in task_group.results["task1"]["answer"]
+            assert task_group.results["task1"]["answer"] == str(dst_file)
 
     def test_scoring_with_no_submission(self, task_group, mock_tools, temp_workspace):
         """Test scoring when no submission is made."""
@@ -605,17 +628,16 @@ loop_
 """
         slabs_content = json.dumps({"slab_1": cif_content, "slab_2": cif_content})
 
-        (temp_workspace / "test_structure.cif").write_text(cif_content)
-        (temp_workspace / "test_slabs.json").write_text(slabs_content)
-        (temp_workspace / "test_data.json").write_text('{"valid": "json"}')
-
         with patch.dict(os.environ, {"CORRAL_WORK_DIR": str(temp_workspace)}):
             environments = create_environments(
                 sample_task_json, work_dir=str(temp_workspace)
             )
 
-            # Complete task 1
+            # Write test files to each environment's trial workspace
             env1 = environments["retrieve_structure"]
+            ws1 = Path(env1.get_current_work_dir())
+            (ws1 / "test_structure.cif").write_text(cif_content)
+
             env1.state.submitted_answer = "test_structure.cif"
             score1 = env1.score()
             assert score1 == 1.0
@@ -625,12 +647,18 @@ loop_
             prompt2 = env2.get_task_prompt()
             assert "Input from retrieve_structure:" in prompt2
 
+            ws2 = Path(env2.get_current_work_dir())
+            (ws2 / "test_slabs.json").write_text(slabs_content)
+
             env2.state.submitted_answer = "test_slabs.json"
             score2 = env2.score()
             assert score2 == 1.0
 
             # Complete independent task 3
             env3 = environments["validate_json"]
+            ws3 = Path(env3.get_current_work_dir())
+            (ws3 / "test_data.json").write_text('{"valid": "json"}')
+
             env3.state.submitted_answer = "test_data.json"
             score3 = env3.score()
             assert score3 == 1.0
@@ -777,7 +805,7 @@ loop_
                 yield temp_path
 
     def test_scoring_resolves_relative_paths(self, scoring_environment):
-        """Test that scoring correctly resolves relative paths."""
+        """Test that scoring resolves relative paths against workspace."""
         task = TaskDefinition(
             name="Test",
             description="Test",
@@ -795,18 +823,23 @@ loop_
             base_work_dir=str(scoring_environment),
         )
 
-        # Test relative path
+        # Copy file to trial workspace
+        workspace = Path(env.get_current_work_dir())
+        src = scoring_environment / "structure.cif"
+        dst = workspace / "structure.cif"
+        dst.write_text(src.read_text())
+
+        # Submit relative path — resolved against workspace
         env.state.submitted_answer = "structure.cif"
         score = env.score()
         assert score == 1.0
 
-        # Check that the resolved path is absolute
-        resolved_path = task_group.results["test"]["answer"]
-        assert Path(resolved_path).is_absolute()
-        assert Path(resolved_path).exists()
+        resolved = task_group.results["test"]["answer"]
+        assert Path(resolved).is_absolute()
+        assert Path(resolved).exists()
 
-    def test_scoring_resolves_paths_from_subdirectories(self, scoring_environment):
-        """Test that scoring finds files in subdirectories."""
+    def test_scoring_resolves_subdirectory_paths(self, scoring_environment):
+        """Test scoring resolves relative subdirectory paths against workspace."""
         task = TaskDefinition(
             name="Test",
             description="Test",
@@ -824,18 +857,24 @@ loop_
             base_work_dir=str(scoring_environment),
         )
 
-        # Submit filename that exists in subdirectory
-        env.state.submitted_answer = "output.cif"
+        # Copy file to trial workspace subdirectory
+        workspace = Path(env.get_current_work_dir())
+        results_dir = workspace / "results"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        src = scoring_environment / "results" / "output.cif"
+        dst = results_dir / "output.cif"
+        dst.write_text(src.read_text())
+
+        # Submit relative subdirectory path
+        env.state.submitted_answer = "results/output.cif"
         score = env.score()
         assert score == 1.0
 
-        # Should resolve to the subdirectory file
-        resolved_path = task_group.results["test"]["answer"]
-        assert "results" in resolved_path
-        assert "output.cif" in resolved_path
+        resolved = task_group.results["test"]["answer"]
+        assert "results/output.cif" in resolved
 
-    def test_scoring_handles_formatted_answers(self, scoring_environment):
-        """Test scoring with various answer formats."""
+    def test_scoring_with_absolute_and_relative_paths(self, scoring_environment):
+        """Test scoring with both absolute and relative paths."""
         task = TaskDefinition(
             name="Test",
             description="Test",
@@ -853,24 +892,28 @@ loop_
             base_work_dir=str(scoring_environment),
         )
 
-        # Test various formatted answers
-        test_cases = [
-            "data.json",
-            "`data.json`",
-            '"data.json"',
-            "'data.json'",
-            "The file is data.json",
-            "Answer: data.json",
-            "Final answer: `data.json`",
-            f"The path is {scoring_environment / 'data.json'}",
-        ]
+        # Copy file to trial workspace
+        workspace = Path(env.get_current_work_dir())
+        src = scoring_environment / "data.json"
+        dst = workspace / "data.json"
+        dst.write_text(src.read_text())
 
-        for answer_format in test_cases:
-            # Reset the task group for each test
-            task_group.results.clear()
-            env.state.submitted_answer = answer_format
-            score = env.score()
-            assert score == 1.0, f"Failed for format: {answer_format}"
+        # Test: Relative path (resolved against workspace)
+        env.state.submitted_answer = "data.json"
+        score = env.score()
+        assert score == 1.0
+
+        # Test: Absolute path (passed through directly)
+        task_group.results.clear()
+        env.state.submitted_answer = str(dst)
+        score = env.score()
+        assert score == 1.0
+
+        # Test: Absolute path to original location
+        task_group.results.clear()
+        env.state.submitted_answer = str(src)
+        score = env.score()
+        assert score == 1.0
 
     def test_scoring_handles_nonexistent_files_gracefully(self, scoring_environment):
         """Test that scoring handles nonexistent files without crashing."""
@@ -907,7 +950,6 @@ loop_
 
     def test_task_dependency_path_resolution(self, scoring_environment):
         """Test path resolution in task dependencies."""
-        # Create tasks with dependencies
         task1 = TaskDefinition(
             name="Task 1",
             description="First task",
@@ -931,7 +973,7 @@ loop_
         tasks = {"task1": task1, "task2": task2}
         task_group = TaskGroup("test", tasks)
 
-        # Complete task1 with a relative path
+        # Complete task1 with absolute path (as WriteFileTool would return)
         env1 = TaskGroupEnvironment(
             task_id="task1",
             task_group=task_group,
@@ -939,7 +981,13 @@ loop_
             base_work_dir=str(scoring_environment),
         )
 
-        env1.state.submitted_answer = "structure.cif"
+        # Copy file to trial workspace and submit absolute path
+        workspace = Path(env1.get_current_work_dir())
+        src = scoring_environment / "structure.cif"
+        dst = workspace / "structure.cif"
+        dst.write_text(src.read_text())
+
+        env1.state.submitted_answer = str(dst)
         score1 = env1.score()
         assert score1 == 1.0
 

--- a/tasks/corral_md/src/corral_md/env.py
+++ b/tasks/corral_md/src/corral_md/env.py
@@ -21,21 +21,12 @@ from tools import (
     visualisation_tool,
 )
 
-from corral.backend.env import Environment
 from corral.backend.server import run_server
 from corral.backend.task import TaskDefinition, TaskGroup
 from corral.backend.tool import Tool
 from corral.utils.context7_tools import get_library_documentation
-from corral.utils.io_tools import (
-    CatFilesTool,
-    CopyFileTool,
-    FileInfoTool,
-    FSManager,
-    GrepTool,
-    ListFilesTool,
-    ReadFileTool,
-    WriteFileTool,
-)
+from corral.utils.io_tools import GrepTool
+from corral.utils.task_group import TaskGroupEnvironment as _BaseTaskGroupEnvironment
 
 SCORING_FUNCTIONS = {
     "check_numerical": check_numerical,
@@ -82,16 +73,6 @@ def load_tasks_from_json(json_path: Path, work_dir: str) -> dict[str, TaskDefini
 
             # Resolve 'target' if it looks like a relative path
             target = scoring_params.get("target")
-            # if isinstance(target, str) and (target.endswith(".data")):
-            # json_dir = Path(task_file).resolve().parent.parent
-            # abs_target_path = Path(json_dir, target).resolve()
-            # logger.info(f"Resolving target path: {abs_target_path}")
-
-            # if not abs_target_path.is_file():
-            #     raise FileNotFoundError(
-            #         f"[{task_id}] Target path does not exist: {abs_target_path}"
-            #     )
-
             scoring_params["target"] = target
 
             # Optionally reassign if task_info is reused later
@@ -115,89 +96,11 @@ def load_tasks_from_json(json_path: Path, work_dir: str) -> dict[str, TaskDefini
     return tasks
 
 
-class TaskGroupEnvironment(Environment):
-    """Environment that works with a task group - simple composition approach"""
-
-    def __init__(
-        self,
-        task_id: str,
-        task_group: TaskGroup,
-        subtask_specific_tools: dict[str, Tool],
-        base_work_dir: str,
-        taskgroup_common_tools: dict[str, Tool] | None = None,
-    ):
-        self.task_group = task_group
-        self.subtask_specific_tools = subtask_specific_tools
-        self.taskgroup_common_tools = taskgroup_common_tools or {}
-
-        if task_id not in task_group.tasks:
-            raise ValueError(f"Task {task_id} not found in task group")
-
-        self.current_task = task_group.tasks[task_id]
-
-        super().__init__(
-            f"{task_id}",
-            base_work_dir=base_work_dir,
-            fs_manager=FSManager("file", base_path=base_work_dir, app="simagent"),
-        )
-
-        # Add tools
-        self._add_task_tools()
-        self._setup_file_tools()
-
-    def _add_task_tools(self):
-        """Add required tools for the task"""
-        for tool_name in self.current_task.tools:
-            if tool_name in self.subtask_specific_tools:
-                self.add_tool(self.subtask_specific_tools[tool_name])
-            else:
-                logger.warning(
-                    f"Tool {tool_name} required for task {self.task_id} not found"
-                )
-
-        for tool in self.taskgroup_common_tools.values():
-            self.add_tool(tool)
-
-    def _setup_file_tools(self):
-        """Setup file tools for current workspace"""
-        if self.current_work_dir:
-            logger.info(
-                f"DEBUG: Setting up FSManager with base_path: {self.current_work_dir}"
-            )
-            # Create new FSManager for current workspace
-            fs_manager = FSManager(
-                "file", base_path=self.current_work_dir, app="simagent"
-            )
-
-            # Add/update file tools
-            self.tools.update(
-                {
-                    "list_files": ListFilesTool(fs_manager),
-                    "read_file": ReadFileTool(fs_manager),
-                    "write_file": WriteFileTool(fs_manager),
-                    "file_info": FileInfoTool(fs_manager),
-                    "cat_files": CatFilesTool(fs_manager),
-                    "copy_file": CopyFileTool(fs_manager),
-                    "grep": GrepTool(fs_manager),
-                    "library_docs": get_library_documentation,
-                    "execute_python_script": execute_python_script,
-                }
-            )
-            logger.info(
-                f"DEBUG: File tools setup complete for workspace: {self.current_work_dir}"
-            )
-        else:
-            logger.warning("DEBUG: No current_work_dir set, skipping file tools setup")
-
-    def reset_state(self) -> str:
-        """Reset state and update file tools for new workspace"""
-        trial_id = super().reset_state()
-        # Recreate file tools for new workspace
-        self._setup_file_tools()
-        return trial_id
+class TaskGroupEnvironment(_BaseTaskGroupEnvironment):
+    """MD-specific environment with domain-specific prompts and scoring."""
 
     def get_task_prompt(self) -> str:
-        """Generate the task prompt for the current task"""
+        """Generate the task prompt with MD-specific guidelines."""
 
         prompt = f"""\nTask: {self.current_task.name}
 Description: {self.current_task.description}
@@ -248,7 +151,6 @@ Required submission format:
                 "   - Density\n"
                 "These quantities should be written at an appropriate, user-configurable frequency (typically 1000 timesteps) suitable for monitoring equilibration and production behavior.\n"
             )
-            # prompt += f"\nIMPORTANT: You have access to filesystem tools. All files will be saved in your isolated workspace.\n Save all the files in {self.current_work_dir} when using tools use this path.\n"
 
         # Add note about dependencies
         if self.current_task.input_from_tasks:
@@ -353,6 +255,11 @@ def create_environments(
         "visualisation_tool": visualisation_tool,
     }
 
+    extra_file_tools = {
+        "library_docs": get_library_documentation,
+        "execute_python_script": execute_python_script,
+    }
+
     environments = {}
     for task_id in task_group.tasks:
         environments[task_id] = TaskGroupEnvironment(
@@ -361,6 +268,9 @@ def create_environments(
             subtask_specific_tools=subtask_specific_tools,
             taskgroup_common_tools=taskgroup_common_tools,
             base_work_dir=work_dir,
+            fsmanager_app="simagent",
+            extra_file_tools=extra_file_tools,
+            extra_fsmanager_tool_classes={"grep": GrepTool},
         )
 
     return environments

--- a/tasks/ml/src/ml/env.py
+++ b/tasks/ml/src/ml/env.py
@@ -16,20 +16,10 @@ from ml.score import (
 )
 from ml.tools import create_ml_tools
 
-from corral.backend.env import Environment
 from corral.backend.server import run_server
 from corral.backend.task import TaskDefinition, TaskGroup
 from corral.backend.tool import Tool
-from corral.utils.io_tools import (
-    CatFilesTool,
-    CopyFileTool,
-    FileInfoTool,
-    FSManager,
-    ListFilesTool,
-    ReadFileTool,
-    WriteFileTool,
-)
-from corral.utils.tool_helpers import smart_resolve_path
+from corral.utils.task_group import TaskGroupEnvironment
 
 logger.info(f"Using BASE_WORK_DIR: {BASE_WORK_DIR}")
 # Registry of scoring functions
@@ -104,166 +94,6 @@ def load_tasks_from_json(
     return tasks
 
 
-class TaskGroupEnvironment(Environment):
-    """Environment that works with a task group - simple composition approach"""
-
-    def __init__(
-        self,
-        task_id: str,
-        task_group: TaskGroup,
-        subtask_specific_tools: dict[str, Tool],
-        base_work_dir: str | Path,
-        taskgroup_common_tools: dict[str, Tool] | None = None,
-    ):
-        self.task_group = task_group
-        self.subtask_specific_tools = subtask_specific_tools
-        self.taskgroup_common_tools = taskgroup_common_tools or {}
-
-        if task_id not in task_group.tasks:
-            raise ValueError(f"Task {task_id} not found in task group")
-
-        self.current_task = task_group.tasks[task_id]
-
-        self.hidden_args = {}
-
-        super().__init__(f"{task_id}", base_work_dir=base_work_dir)
-
-        self.hidden_args = {"work_dir": self.get_current_work_dir()}
-
-        # Add tools
-        self._add_task_tools()
-        self._setup_file_tools()
-
-    def _add_task_tools(self):
-        """Add required tools for the task"""
-        for tool_name in self.current_task.tools:
-            if tool_name in self.subtask_specific_tools:
-                self.add_tool(self.subtask_specific_tools[tool_name])
-            else:
-                logger.warning(
-                    f"Tool {tool_name} required for task {self.task_id} not found"
-                )
-
-        for tool in self.taskgroup_common_tools.values():
-            self.add_tool(tool)
-
-    def _setup_file_tools(self):
-        """Setup file tools for current workspace"""
-        if self.current_work_dir:
-            logger.info(
-                f"DEBUG: Setting up FSManager with base_path: {self.current_work_dir}"
-            )
-            # Create new FSManager for current workspace
-            fs_manager = FSManager("file", base_path=self.current_work_dir)
-
-            # Add/update file tools
-            self.tools.update(
-                {
-                    "list_files": ListFilesTool(fs_manager),
-                    "read_file": ReadFileTool(fs_manager),
-                    "write_file": WriteFileTool(fs_manager),
-                    "file_info": FileInfoTool(fs_manager),
-                    "cat_files": CatFilesTool(fs_manager),
-                    "copy_file": CopyFileTool(fs_manager),
-                }
-            )
-            logger.info(
-                f"DEBUG: File tools setup complete for workspace: {self.current_work_dir}"
-            )
-        else:
-            logger.warning("DEBUG: No current_work_dir set, skipping file tools setup")
-
-    def reset_state(self) -> str:
-        """Reset state and update file tools for new workspace"""
-        trial_id = super().reset_state()
-
-        if hasattr(self, "hidden_args"):
-            self.hidden_args = {"work_dir": self.get_current_work_dir()}
-
-        # Recreate file tools for new workspace
-        self._setup_file_tools()
-        return trial_id
-
-    def get_task_prompt(self) -> str:
-        """Generate the task prompt for the current task"""
-        _combined_input = self.task_group.get_task_input(self.task_id)
-
-        prompt = f"""Task: {self.current_task.name}
-Description: {self.current_task.description}
-
-Required submission format:
-{self.current_task.submission_format}
-
-"""
-
-        prompt += "\nAvailable input data:\n"
-
-        # Display input data from dependencies
-        for dep_task_id in self.current_task.input_from_tasks:
-            if dep_task_id in self.task_group.results:
-                dep_result = self.task_group.results[dep_task_id]
-                if isinstance(dep_result, dict) and "answer" in dep_result:
-                    prompt += f"- Input from {dep_task_id}: {dep_result['answer']}\n"
-                else:
-                    prompt += f"- Input from {dep_task_id}: {dep_result}\n"
-
-        # Display initial input data
-        if self.current_task.initial_input:
-            for key, value in self.current_task.initial_input.items():
-                if key != "work_dir":
-                    prompt += f"- {key}: {value}\n"
-
-        # Add workspace info
-        if self.current_work_dir:
-            prompt += f"\nIMPORTANT: You have access to filesystem tools. All files will be saved in your isolated workspace {self.current_work_dir}\n"
-
-        # Add note about dependencies
-        if self.current_task.input_from_tasks:
-            status = []
-            for dep_id in self.current_task.input_from_tasks:
-                status_text = (
-                    "available"
-                    if dep_id in self.task_group.results
-                    else "not yet available"
-                )
-                status.append(f"{dep_id} ({status_text})")
-
-            prompt += f"\n\nThis task uses output from tasks: {', '.join(status)}"
-
-        return prompt
-
-    def score(self) -> float:
-        """Score the submitted answer"""
-        if not self.state.submitted_answer:
-            logger.warning(f"No submission found for task {self.task_id}")
-            return 0.0
-
-        try:
-            # Get and log the raw submission
-            answer_value = self.state.submitted_answer.strip()
-            logger.info(f"Raw submission for {self.task_id}: {answer_value!r}")
-            resolved_answer = smart_resolve_path(answer_value)
-            logger.info(f"Resolved answer for {self.task_id}: {resolved_answer!r}")
-            # Call the scoring function with the raw answer
-            score = self.current_task.scoring_fn(resolved_answer)
-
-            # Store result in task group
-            self.task_group.store_result(
-                self.task_id, {"answer": resolved_answer}, score
-            )
-            logger.info(f"Task {self.task_id} scored: {score}")
-
-            return score
-
-        except Exception as e:
-            logger.error(
-                f"Error scoring submission for task {self.task_id}: {e!s}",
-                exc_info=True,
-            )
-            logger.error(f"Submission was: {self.state.submitted_answer!r}")
-            return 0.0
-
-
 def create_environments(
     task_json_path: str | Path,
     taskgroup_common_tools: dict[str, Tool] | None = None,
@@ -305,7 +135,6 @@ def create_environments(
     subtask_specific_tools = create_ml_tools()
 
     # Create environments for all tasks
-
     environments = {}
     for task_id in task_group.tasks:
         environments[task_id] = TaskGroupEnvironment(
@@ -314,6 +143,7 @@ def create_environments(
             subtask_specific_tools=subtask_specific_tools,
             taskgroup_common_tools=taskgroup_common_tools,
             base_work_dir=work_dir,
+            hidden_args_keys=["work_dir"],
         )
 
     return environments

--- a/tasks/ml/src/ml/score.py
+++ b/tasks/ml/src/ml/score.py
@@ -16,37 +16,6 @@ BASE_WORK_DIR = os.environ.get("CORRAL_WORK_DIR", f"../CORRAL_WORK_DIR/ml_{uid}"
 os.environ["CORRAL_WORK_DIR"] = BASE_WORK_DIR
 
 
-def resolve_path(path_or_str: str) -> str:
-    """
-    Resolves a path that might be relative to the base work directory.
-    Also cleans up common input format issues.
-    """
-    # Handle various input issues
-    if isinstance(path_or_str, str):
-        # Remove "answer:" prefix if present
-        if path_or_str.startswith("answer:"):
-            path_or_str = path_or_str.replace("answer:", "", 1).strip()
-
-        # Replace escaped quotes that might come from JSON strings
-        path_or_str = path_or_str.replace('\\"', '"').replace("\\'", "'")
-
-    try:
-        # If it's an absolute path or already exists, return as is
-        if Path(path_or_str).is_absolute() or Path(path_or_str).exists():
-            return path_or_str
-
-        # Try to resolve against base directory
-        full_path = Path(BASE_WORK_DIR) / path_or_str
-        if full_path.exists():
-            return str(full_path)
-
-        # If we can't resolve it, return the original
-        return path_or_str
-    except Exception:
-        # If there's any error treating it as a path, return the original
-        return path_or_str
-
-
 def check_mp_structure(path_or_cif: str) -> float:
     """
     Check if the path points to a valid CIF file containing a structure from Materials Project.

--- a/tasks/ml/src/ml/tools.py
+++ b/tasks/ml/src/ml/tools.py
@@ -22,18 +22,14 @@ if "MP_API_KEY" not in os.environ:
 
 
 def resolve_working_dir_path(path_or_str: str, work_dir: str | None = None) -> str:
-    """Resolve path relative to the current working directory"""
-    if not Path(path_or_str).is_absolute():
-        if work_dir:
-            return str(Path(work_dir) / path_or_str)
-        else:
-            work_dir = os.getenv("CORRAL_WORK_DIR")
-            if work_dir:
-                return str(Path(work_dir) / path_or_str)
-
-            # Fallback to current directory if no work_dir provided
-            return str(Path.cwd() / path_or_str)
-    return path_or_str
+    """Resolve path relative to work_dir. Absolute paths pass through."""
+    if Path(path_or_str).is_absolute():
+        return path_or_str
+    if not work_dir:
+        work_dir = os.getenv("CORRAL_WORK_DIR")
+    if not work_dir:
+        return str(Path.cwd() / path_or_str)
+    return str(Path(work_dir) / path_or_str)
 
 
 @tool
@@ -935,7 +931,8 @@ def consolidate_polymorph_datasets(
 
     for composition, file_path in composition_files.items():
         try:
-            with Path(file_path).open() as f:
+            resolved_path = resolve_working_dir_path(file_path, work_dir)
+            with Path(resolved_path).open() as f:
                 polymorphs = json.load(f)
 
             # Add composition information to each polymorph
@@ -1093,7 +1090,8 @@ def select_polymorphs_with_strategy_to_file(
     [/LIMITATIONS]
     """
     if is_path:
-        with Path(polymorphs_data).open("r") as f:
+        resolved_path = resolve_working_dir_path(polymorphs_data, work_dir)
+        with Path(resolved_path).open("r") as f:
             polymorphs = json.loads(f.read())
     else:
         polymorphs = json.loads(polymorphs_data)
@@ -1227,6 +1225,7 @@ def filter_json_with_strategy(
     [/LIMITATIONS]
     """
     try:
+        input_json_path = resolve_working_dir_path(input_json_path, work_dir)
         with Path(input_json_path).open("r") as f:
             data = json.load(f)
 
@@ -1414,6 +1413,7 @@ def prepare_tabular_dataset(
         output_dir.mkdir(parents=True, exist_ok=True)
 
         # Load polymorphs data
+        polymorphs_json_path = resolve_working_dir_path(polymorphs_json_path, work_dir)
         with Path(polymorphs_json_path).open("r") as f:
             polymorphs = json.load(f)
 
@@ -1834,6 +1834,8 @@ def train_xgboost_model(
     """
     try:
         # Load data
+        train_data_path = resolve_working_dir_path(train_data_path, work_dir)
+        test_data_path = resolve_working_dir_path(test_data_path, work_dir)
         train_df = pd.read_csv(train_data_path)
         test_df = pd.read_csv(test_data_path)
 

--- a/tasks/ml/src/ml/utils.py
+++ b/tasks/ml/src/ml/utils.py
@@ -1,66 +1,9 @@
-import os
-import re
-from pathlib import Path
+# Re-export path resolution utilities from the canonical source.
+# These were previously duplicated here; now they live in corral.utils.tool_helpers.
+from corral.utils.tool_helpers import (
+    extract_path_from_answer,
+    find_file_by_name,
+    smart_resolve_path,
+)
 
-
-def extract_path_from_answer(answer: str) -> str:
-    """Extract file path from agent answers"""
-    if not isinstance(answer, str):
-        return str(answer)
-
-    answer = answer.strip()
-
-    # Remove prefixes
-    if answer.startswith("answer:"):
-        answer = answer.replace("answer:", "", 1).strip()
-
-    # Extract from markdown backticks: `path/file.json`
-    markdown_match = re.search(r"`([^`]+\.[a-zA-Z0-9]+)`", answer)
-    if markdown_match:
-        return markdown_match.group(1)
-
-    # Extract from quotes: "path/file.json" or 'path/file.json'
-    quote_match = re.search(r'["\']([^"\']+\.[a-zA-Z0-9]+)["\']', answer)
-    if quote_match:
-        return quote_match.group(1)
-
-    # Extract absolute paths: /path/to/file.json
-    abs_match = re.search(r"(/[^\s]+\.[a-zA-Z0-9]+)", answer)
-    if abs_match:
-        return abs_match.group(1)
-
-    # Extract any file pattern: filename.json
-    file_match = re.search(r"([^\s]+\.[a-zA-Z0-9]+)", answer)
-    if file_match:
-        return file_match.group(1)
-
-    return answer
-
-
-def find_file_by_name(filename: str, base_dir: str | None = None) -> str:
-    """Find file by name in workspace"""
-    if not base_dir:
-        base_dir = os.environ.get("CORRAL_WORK_DIR", "")
-
-    if not base_dir or not Path(base_dir).exists():
-        return filename
-
-    # Search for the file recursively
-    base_path = Path(base_dir)
-    matches = list(base_path.rglob(filename))
-
-    if matches:
-        # Return the most recent file
-        return str(max(matches, key=lambda x: x.stat().st_mtime))
-
-    return filename
-
-
-def smart_resolve_path(input_path: str) -> str:
-    """Resolve path intelligently - use absolute path if exists, search only as fallback"""
-    extracted_path = extract_path_from_answer(input_path)
-
-    if Path(extracted_path).exists():
-        return extracted_path  # Use the extracted path directly
-    else:
-        return find_file_by_name(Path(extracted_path).name)  # Search as fallback
+__all__ = ["extract_path_from_answer", "find_file_by_name", "smart_resolve_path"]

--- a/tasks/ml/tests/test_unit.py
+++ b/tasks/ml/tests/test_unit.py
@@ -14,7 +14,6 @@ from ml.score import (
     check_mp_structure,
     compare_with_ground_truth,
     ml_pipeline_score,
-    resolve_path,
 )
 
 # Import the tool objects to test
@@ -61,19 +60,6 @@ class TestUtilityFunctions:
 
         result = smart_resolve_path(str(test_file))
         assert result == str(test_file)
-
-    def test_resolve_path_with_prefix(self):
-        """Test resolve_path function with various prefixes."""
-        test_cases = [
-            "answer: /path/to/file.json",
-            "file.json",
-            "/absolute/path/file.json",
-        ]
-
-        for test_case in test_cases:
-            result = resolve_path(test_case)
-            assert isinstance(result, str)
-            assert "answer:" not in result
 
 
 class TestJSONProcessing:

--- a/tasks/resistor_network/src/resistor_network/score.py
+++ b/tasks/resistor_network/src/resistor_network/score.py
@@ -9,8 +9,6 @@ from typing import Any
 import numpy as np
 from loguru import logger
 
-from corral.utils.tool_helpers import smart_resolve_path
-
 # Generate a random 4-letter unique identifier
 uid = "".join(secrets.choice(string.ascii_lowercase) for _ in range(6))
 
@@ -336,7 +334,7 @@ def check_resistance_measurements(
             logger.info(f"check_resistance_measurements: input={topology_input!r}")
 
             # Load topology
-            resolved_input = smart_resolve_path(topology_input.strip())
+            resolved_input = topology_input.strip()
             topology_data = None
 
             if Path(resolved_input).exists():
@@ -518,7 +516,7 @@ def check_resistor_values_only(
             logger.info(f"check_resistor_values_only: input={values_input!r}")
 
             # Try to resolve and load values
-            resolved_input = smart_resolve_path(values_input.strip())
+            resolved_input = values_input.strip()
             values_data = None
 
             if Path(resolved_input).exists():

--- a/tasks/samplemath/samplemath/env_subtask.py
+++ b/tasks/samplemath/samplemath/env_subtask.py
@@ -7,19 +7,10 @@ from pathlib import Path
 from loguru import logger
 from tools import calculator, number_converter
 
-from corral.backend.env import Environment
 from corral.backend.server import run_server
 from corral.backend.task import TaskDefinition, TaskGroup
 from corral.backend.tool import Tool
-from corral.utils.io_tools import (
-    CatFilesTool,
-    CopyFileTool,
-    FileInfoTool,
-    FSManager,
-    ListFilesTool,
-    ReadFileTool,
-    WriteFileTool,
-)
+from corral.utils.task_group import TaskGroupEnvironment
 
 # Base working directory
 if "CORRAL_WORK_DIR" not in os.environ:
@@ -181,172 +172,6 @@ def load_tasks_from_json(
     return tasks
 
 
-class TaskGroupEnvironment(Environment):
-    """Environment that works with a task group - simple composition approach"""
-
-    def __init__(
-        self,
-        task_id: str,
-        task_group: TaskGroup,
-        subtask_specific_tools: dict[str, Tool],
-        base_work_dir: str,
-        taskgroup_common_tools: dict[str, Tool] | None = None,
-    ):
-        self.task_group = task_group
-        self.subtask_specific_tools = subtask_specific_tools
-        self.taskgroup_common_tools = taskgroup_common_tools or {}
-
-        if task_id not in task_group.tasks:
-            raise ValueError(f"Task {task_id} not found in task group")
-
-        self.raw_task_id = task_id
-        self.current_task = task_group.tasks[task_id]
-
-        super().__init__(
-            f"{task_group.group_id}_{task_id}", base_work_dir=base_work_dir
-        )
-
-        # Add tools
-        self._add_task_tools()
-        self._setup_file_tools()
-
-    def _add_task_tools(self):
-        """Add required tools for the task"""
-        for tool_name in self.current_task.tools:
-            if tool_name in self.subtask_specific_tools:
-                self.add_tool(self.subtask_specific_tools[tool_name])
-            else:
-                logger.warning(
-                    f"Tool {tool_name} required for task {self.task_id} not found"
-                )
-
-        for tool in self.taskgroup_common_tools.values():
-            self.add_tool(tool)
-
-    def _setup_file_tools(self):
-        """Setup file tools for current workspace"""
-        if self.current_work_dir:
-            logger.info(
-                f"DEBUG: Setting up FSManager with base_path: {self.current_work_dir}"
-            )
-            # Create new FSManager for current workspace
-            fs_manager = FSManager("file", base_path=self.current_work_dir)
-
-            # Add/update file tools
-            self.tools.update(
-                {
-                    "list_files": ListFilesTool(fs_manager),
-                    "read_file": ReadFileTool(fs_manager),
-                    "write_file": WriteFileTool(fs_manager),
-                    "file_info": FileInfoTool(fs_manager),
-                    "cat_files": CatFilesTool(fs_manager),
-                    "copy_file": CopyFileTool(fs_manager),
-                }
-            )
-            logger.info(
-                f"DEBUG: File tools setup complete for workspace: {self.current_work_dir}"
-            )
-        else:
-            logger.warning("DEBUG: No current_work_dir set, skipping file tools setup")
-
-    def reset_state(self) -> str:
-        """Reset state and update file tools for new workspace"""
-        trial_id = super().reset_state()
-        # Recreate file tools for new workspace
-        self._setup_file_tools()
-        return trial_id
-
-    def get_task_prompt(self) -> str:
-        """Generate the task prompt for the current task"""
-        _combined_input = self.task_group.get_task_input(self.task_id)
-
-        prompt = f"""Task: {self.current_task.name}
-    Description: {self.current_task.description}
-
-    Required submission format:
-    {self.current_task.submission_format}
-
-    """
-
-        prompt += "\nAvailable input data:\n"
-
-        # Debug: Log the task group results
-        logger.info(f"DEBUG: Task group results: {self.task_group.results}")
-        logger.info(
-            f"DEBUG: Current task dependencies: {self.current_task.input_from_tasks}"
-        )
-
-        # Display input data from dependencies
-        for dep_task_id in self.current_task.input_from_tasks:
-            logger.info(f"DEBUG: Checking dependency {dep_task_id}")
-            if dep_task_id in self.task_group.results:
-                dep_result = self.task_group.results[dep_task_id]
-                logger.info(f"DEBUG: Found result for {dep_task_id}: {dep_result}")
-                if isinstance(dep_result, dict) and "answer" in dep_result:
-                    prompt += f"- Input from {dep_task_id}: {dep_result['answer']}\n"
-                else:
-                    prompt += f"- Input from {dep_task_id}: {dep_result}\n"
-            else:
-                logger.warning(f"DEBUG: No result found for dependency {dep_task_id}")
-                prompt += f"- Input from {dep_task_id}: NOT YET AVAILABLE\n"
-
-        # Display initial input data
-        if self.current_task.initial_input:
-            for key, value in self.current_task.initial_input.items():
-                if key != "work_dir":
-                    prompt += f"- {key}: {value}\n"
-
-        # Add workspace info
-        if self.current_work_dir:
-            prompt += "\nIMPORTANT: You have access to filesystem tools. All files will be saved in your isolated workspace.\n"
-
-        # Add note about dependencies
-        if self.current_task.input_from_tasks:
-            status = []
-            for dep_id in self.current_task.input_from_tasks:
-                status_text = (
-                    "available"
-                    if dep_id in self.task_group.results
-                    else "not yet available"
-                )
-                status.append(f"{dep_id} ({status_text})")
-
-            prompt += f"\n\nThis task uses output from tasks: {', '.join(status)}"
-
-        logger.info(f"DEBUG: Generated prompt for {self.task_id}:\n{prompt}")
-        return prompt
-
-    def score(self) -> float:
-        """Score the submitted answer"""
-        if not self.state.submitted_answer:
-            logger.warning(f"No submission found for task {self.task_id}")
-            return 0.0
-
-        try:
-            # Get and log the raw submission
-            answer_value = self.state.submitted_answer.strip()
-            logger.info(f"Raw submission for {self.task_id}: {answer_value!r}")
-
-            # Call the scoring function with the raw answer
-            score = self.current_task.scoring_fn(answer_value)
-
-            # Store result in task group
-            self.task_group.store_result(
-                self.raw_task_id, {"answer": answer_value}, score
-            )
-            logger.info(f"Task {self.task_id} scored: {score}")
-
-            return score
-
-        except Exception as e:
-            logger.error(
-                f"Error scoring submission for task {self.task_id}: {e!s}",
-                exc_info=True,
-            )
-            logger.error(f"Submission was: {self.state.submitted_answer!r}")
-            return 0.0
-
-
 def create_environments(
     task_json_path: str | Path,
     taskgroup_common_tools: dict[str, Tool] | None = None,
@@ -385,7 +210,6 @@ def create_environments(
         logger.info(f"{i+1}. {task_id}")
 
     # Create environments for all tasks
-
     environments = {}
     for task_id in task_group.tasks:
         environments[task_id] = TaskGroupEnvironment(

--- a/tests/test_workspace_registry.py
+++ b/tests/test_workspace_registry.py
@@ -1,0 +1,155 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from corral.utils.workspace_registry import WorkspaceEntry, WorkspaceRegistry
+
+
+@pytest.fixture()
+def tmp_work_dir(tmp_path):
+    """Create a temporary work directory."""
+    return str(tmp_path / "workdir")
+
+
+@pytest.fixture()
+def registry(tmp_work_dir):
+    """Create a WorkspaceRegistry in a temp dir."""
+    return WorkspaceRegistry(tmp_work_dir)
+
+
+class TestWorkspaceRegistryInit:
+    def test_creates_db_file(self, tmp_work_dir):
+        WorkspaceRegistry(tmp_work_dir)
+        db_path = Path(tmp_work_dir) / WorkspaceRegistry.DB_FILENAME
+        assert db_path.exists()
+
+    def test_creates_base_dir(self, tmp_path):
+        work_dir = str(tmp_path / "nonexistent" / "deep" / "dir")
+        WorkspaceRegistry(work_dir)
+        assert Path(work_dir).exists()
+
+    def test_tables_exist(self, registry):
+        conn = sqlite3.connect(registry.db_path)
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = {t[0] for t in tables}
+        assert "workspaces" in table_names
+        assert "files" in table_names
+        conn.close()
+
+    def test_idempotent_init(self, tmp_work_dir):
+        """Creating registry twice on same dir should not fail."""
+        reg1 = WorkspaceRegistry(tmp_work_dir)
+        reg1.register_workspace("task1", "0", "uuid-1", "/path/1")
+        reg2 = WorkspaceRegistry(tmp_work_dir)
+        # Data from reg1 should still be there
+        entry = reg2.get_by_id("uuid-1")
+        assert entry is not None
+        assert entry.task_id == "task1"
+
+
+class TestRegisterWorkspace:
+    def test_register_and_retrieve(self, registry):
+        entry = registry.register_workspace("task_a", "0", "uuid-abc", "/some/path")
+        assert isinstance(entry, WorkspaceEntry)
+        assert entry.workspace_id == "uuid-abc"
+        assert entry.task_id == "task_a"
+        assert entry.trial_id == "0"
+        assert entry.status == "active"
+        assert entry.completed_at is None
+
+    def test_get_by_id(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-abc", "/some/path")
+        result = registry.get_by_id("uuid-abc")
+        assert result is not None
+        assert result.workspace_id == "uuid-abc"
+
+    def test_get_by_id_not_found(self, registry):
+        result = registry.get_by_id("nonexistent")
+        assert result is None
+
+    def test_multiple_workspaces(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-1", "/path/1")
+        registry.register_workspace("task_a", "1", "uuid-2", "/path/2")
+        registry.register_workspace("task_b", "0", "uuid-3", "/path/3")
+
+        all_ws = registry.get_workspaces()
+        assert len(all_ws) == 3
+
+        task_a_ws = registry.get_workspaces(task_id="task_a")
+        assert len(task_a_ws) == 2
+
+        task_b_ws = registry.get_workspaces(task_id="task_b")
+        assert len(task_b_ws) == 1
+
+
+class TestUpdateStatus:
+    def test_update_to_completed(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-1", "/path/1")
+        registry.update_status(
+            "uuid-1", "completed", completed_at="2026-01-01T00:00:00Z"
+        )
+
+        entry = registry.get_by_id("uuid-1")
+        assert entry.status == "completed"
+        assert entry.completed_at == "2026-01-01T00:00:00Z"
+
+    def test_filter_by_status(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-1", "/path/1")
+        registry.register_workspace("task_a", "1", "uuid-2", "/path/2")
+        registry.update_status("uuid-1", "completed")
+
+        active = registry.get_workspaces(status="active")
+        assert len(active) == 1
+        assert active[0].workspace_id == "uuid-2"
+
+        completed = registry.get_workspaces(status="completed")
+        assert len(completed) == 1
+        assert completed[0].workspace_id == "uuid-1"
+
+
+class TestFileTracking:
+    def test_register_and_find_file(self, registry):
+        registry.register_workspace(
+            "task_a", "0", "uuid-1", "/work/task_a_trial_0_uuid1"
+        )
+        registry.register_file(
+            "uuid-1", "result.json", "/work/task_a_trial_0_uuid1/result.json"
+        )
+
+        found = registry.find_file("result.json")
+        assert found == "/work/task_a_trial_0_uuid1/result.json"
+
+    def test_find_file_scoped_to_task(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-1", "/path/1")
+        registry.register_workspace("task_b", "0", "uuid-2", "/path/2")
+        registry.register_file("uuid-1", "output.cif", "/path/1/output.cif")
+        registry.register_file("uuid-2", "output.cif", "/path/2/output.cif")
+
+        # Without task scope, returns most recent
+        found = registry.find_file("output.cif")
+        assert found is not None
+
+        # Scoped to task_a
+        found_a = registry.find_file("output.cif", task_id="task_a")
+        assert found_a == "/path/1/output.cif"
+
+        # Scoped to task_b
+        found_b = registry.find_file("output.cif", task_id="task_b")
+        assert found_b == "/path/2/output.cif"
+
+    def test_find_file_not_found(self, registry):
+        result = registry.find_file("nonexistent.txt")
+        assert result is None
+
+    def test_find_file_returns_most_recent(self, registry):
+        registry.register_workspace("task_a", "0", "uuid-1", "/path/1")
+        registry.register_workspace("task_a", "1", "uuid-2", "/path/2")
+        registry.register_file("uuid-1", "data.json", "/path/1/data.json")
+        registry.register_file("uuid-2", "data.json", "/path/2/data.json")
+
+        # Should return the most recently registered one (uuid-2)
+        found = registry.find_file("data.json")
+        assert found == "/path/2/data.json"


### PR DESCRIPTION
## Summary
- **Remove heuristic path resolution (`smart_resolve_path`, `rglob`, regex parsing) from the scoring hot path** — replaced with deterministic resolution: relative paths are prepended with the trial workspace directory, absolute paths and JSON data pass through unchanged.
- **WriteFileTool and CopyFileTool now return absolute paths** so agents see the real file location, closing the FSManager abstraction gap.
- **FSManager scoped to per-trial workspace** instead of the global `base_work_dir`, so relative paths from tools resolve correctly within each trial.
- **Dead `resolve_path` functions removed** from catalyst and ML score modules.
- **ML tools fixed** to consistently resolve paths via `resolve_working_dir_path` (consolidate, select, filter, prepare, train tools).

### Files changed
| File | Change |
|------|--------|
| `src/corral/utils/task_group.py` | Deterministic `score()`, FSManager scoped to trial workspace |
| `src/corral/utils/io_tools.py` | WriteFileTool/CopyFileTool return absolute paths |
| `tasks/catalyst/src/catalyst/score.py` | Remove `smart_resolve_path`, dead `resolve_path` |
| `tasks/ml/src/ml/score.py` | Remove dead `resolve_path` |
| `tasks/ml/src/ml/tools.py` | Simplify + fix path resolution in tools |
| `tasks/resistor_network/src/resistor_network/score.py` | Remove `smart_resolve_path` |
| `tasks/catalyst/tests/test_environment_integration.py` | Updated for new path behavior |
| `tasks/ml/tests/test_unit.py` | Remove deleted `resolve_path` test |

## Test plan
- [ ] `cd tasks/catalyst && CORRAL_WORK_DIR=$(mktemp -d) uv run python -m pytest tests -v --rootdir=.`
- [ ] `cd tasks/ml && CORRAL_WORK_DIR=$(mktemp -d) uv run python -m pytest tests -v --rootdir=.`
- [ ] `cd tasks/resistor_network && CORRAL_WORK_DIR=$(mktemp -d) uv run python -m pytest tests -v --rootdir=.`
- [ ] Run catalyst + ML benchmarks end-to-end (ToolCalling and ReAct)