### PR TITLE
feat: make the retro database sharable

### DIFF
--- a/tasks/retrosynthesis/README.md
+++ b/tasks/retrosynthesis/README.md
@@ -1,6 +1,43 @@
 # Environment with Retrosynthesis Task
 
-Install environment
+## Database Setup
+
+The retrosynthesis environment requires a PostgreSQL database with RDKit extensions containing two databases: `reactions_raw_db` and `reactions_production_db`.
+
+### Quick Start (recommended)
+
+> **Note:** The Docker image is hosted on GHCR. If the package is private, you must authenticate first:
+> ```bash
+> echo "YOUR_GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+> ```
+> A [GitHub PAT](https://github.com/settings/tokens) with `read:packages` scope is sufficient.
+> If the package has been made public, no token is needed.
+
+Run the setup script to pull and start the pre-seeded database:
+
+```bash
+cd tasks/retrosynthesis/docker
+bash setup_retro_db.sh
+```
+
+On first startup, PostgreSQL will initialize and restore both databases (this takes a few minutes). Monitor progress with:
+
+```bash
+docker logs -f corral-retro-db
+```
+
+### Manual Pull
+
+```bash
+docker pull ghcr.io/lamalab-org/corral-retro-db:v1
+docker run --name corral-retro-db \
+  -p 5432:5432 \
+  -e POSTGRES_PASSWORD=postgres \
+  -v corral-retro-db:/var/lib/postgresql/data \
+  -d ghcr.io/lamalab-org/corral-retro-db:v1
+```
+
+## Install environment
 
 ```bash
 cd tasks/retrosynthesis
@@ -8,14 +45,14 @@ uv venv --python 3.11.0
 uv sync
 ```
 
-Run the environment
+## Run the environment
 
 ```bash
 cd tasks/retrosynthesis
 python -m env
 ```
 
-see the tasks
+## See the tasks
 
 ```bash
 curl http://localhost:8000/tasks/

--- a/tasks/retrosynthesis/docker/Dockerfile
+++ b/tasks/retrosynthesis/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM informaticsmatters/rdkit-cartridge-debian:latest
+
+COPY reactions_raw_db.sql.gz /seed/
+COPY reactions_production_db.sql.gz /seed/
+COPY 01-restore.sh /docker-entrypoint-initdb.d/01-restore.sh
+RUN chmod +x /docker-entrypoint-initdb.d/01-restore.sh

--- a/tasks/retrosynthesis/docker/restore.sh
+++ b/tasks/retrosynthesis/docker/restore.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+echo "Creating databases..."
+createdb -U "$POSTGRES_USER" reactions_raw_db
+createdb -U "$POSTGRES_USER" reactions_production_db
+
+echo "Restoring reactions_raw_db..."
+gunzip -c /seed/reactions_raw_db.sql.gz | psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d reactions_raw_db
+echo "reactions_raw_db restored."
+
+echo "Restoring reactions_production_db..."
+gunzip -c /seed/reactions_production_db.sql.gz | psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d reactions_production_db
+echo "reactions_production_db restored."
+
+echo "All databases restored successfully."

--- a/tasks/retrosynthesis/docker/setup_retro_db.sh
+++ b/tasks/retrosynthesis/docker/setup_retro_db.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# setup_retro_db.sh — Pull and run the corral retrosynthesis database
+set -euo pipefail
+
+IMAGE="ghcr.io/lamalab-org/corral-retro-db:v1"
+CONTAINER_NAME="corral-retro-db"
+VOLUME_NAME="corral-retro-db"
+PORT="${RETRO_DB_PORT:-5432}"
+PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+
+# If the package is private, authenticate to GHCR first:
+#   echo "YOUR_GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+# Or set GITHUB_TOKEN env var and this script will do it automatically:
+if [[ -n "${GITHUB_TOKEN:-}" && -n "${GITHUB_USER:-}" ]]; then
+    echo "==> Logging in to ghcr.io as ${GITHUB_USER}..."
+    echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_USER}" --password-stdin
+fi
+
+echo "==> Pulling ${IMAGE}..."
+docker pull "${IMAGE}"
+
+# Stop and remove existing container if present
+if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    echo "==> Removing existing container ${CONTAINER_NAME}..."
+    docker rm -f "${CONTAINER_NAME}"
+fi
+
+echo "==> Starting ${CONTAINER_NAME} on port ${PORT}..."
+docker run \
+    --name "${CONTAINER_NAME}" \
+    -p "${PORT}:5432" \
+    -e POSTGRES_PASSWORD="${PASSWORD}" \
+    -v "${VOLUME_NAME}:/var/lib/postgresql/data" \
+    -d "${IMAGE}"
+
+echo ""
+echo "Container started. On first run, database restoration takes a few minutes."
+echo "Monitor progress with:  docker logs -f ${CONTAINER_NAME}"
+echo ""
+echo "Connection details:"
+echo "  Host:     localhost"
+echo "  Port:     ${PORT}"
+echo "  User:     postgres"
+echo "  Password: ${PASSWORD}"
+echo "  Databases: reactions_raw_db, reactions_production_db"


### PR DESCRIPTION
## Summary by Sourcery

Add a sharable, pre-seeded PostgreSQL RDKit database image and scripts for the retrosynthesis task, and document how to set it up and run it.

New Features:
- Provide a Docker image and setup script to run a pre-seeded PostgreSQL RDKit database for the retrosynthesis environment.
- Add a database restore script and Dockerfile to seed reactions_raw_db and reactions_production_db on container initialization.

Documentation:
- Document database requirements and add quick-start and manual Docker instructions for setting up the retrosynthesis database.