### PR TITLE
ci: enable site deployment on push to dev

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Deploy Site & Docs
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     paths:
       - docs/**
@@ -65,7 +65,7 @@ jobs:
           path: _build
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- Add `dev` branch to the push trigger for the Deploy Site & Docs workflow
- Update deploy job condition to also deploy on pushes to `dev`

## Test plan
- [ ] Merge to dev and verify the deploy job runs (not skipped)
- [ ] Verify site is live at https://lamalab-org.github.io/corral/

## Summary by Sourcery

Enable documentation site deployment from the dev branch in the GitHub Actions workflow.

CI:
- Trigger the docs deployment workflow on pushes to both main and dev branches.
- Allow the deploy job to run for push events from either main or dev.