### PR TITLE
fix: solve the blog hyperlinks in explorer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1021,7 +1021,7 @@
     <div x-show="activeTab === 'explainers'" x-cloak class="flex-1 flex flex-col" style="min-height: calc(100vh - 80px);">
 
       <!-- 3-column layout -->
-      <div class="flex-1 flex" x-data="traceExplorer()">
+      <div class="flex-1 flex" x-data="traceExplorer()" x-init="initExplorer()">
 
         <!-- LEFT SIDEBAR -->
         <aside class="w-[280px] flex-shrink-0 border-r border-slate-200 dark:border-slate-700 overflow-y-auto bg-white dark:bg-[#1e293b] p-4 space-y-5">
@@ -1816,7 +1816,10 @@
         svgZoom: null,
         svgGroup: null,
 
-        init() {
+        // Named (not "init") and called via x-init: this is a nested x-data inside
+        // corralApp, whose own init() shadows a child init() in Alpine's merged scope,
+        // so Alpine never auto-runs it. An explicit, uniquely-named hook is reliable.
+        initExplorer() {
           // Deep-link: "#explainers?trace=<id>" auto-selects that trace.
           const raw = window.location.hash.slice(1);
           const qi = raw.indexOf('?');


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix blog/explorer deep-linking by explicitly calling the trace explorer initialization function instead of relying on Alpine's shadowed init hook.