### PR TITLE
fix: solve issues #390, #391 and #392

### DIFF
--- a/docker/benchmark.Dockerfile
+++ b/docker/benchmark.Dockerfile
@@ -7,12 +7,10 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN groupadd --gid 10001 corral-terminal \
-    && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /workspace corral-terminal
-
 WORKDIR /opt/corral
 COPY . /opt/corral
-RUN python -m pip install --no-cache-dir -e .
+RUN python -m pip install --no-cache-dir -e . \
+    && python -m corral.runtime.permissions --prepare-image
 
 VOLUME ["/workspace"]
 CMD ["corral", "--help"]

--- a/docker/benchmark.Dockerfile
+++ b/docker/benchmark.Dockerfile
@@ -3,12 +3,16 @@ FROM python:3.12-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --gid 10001 corral-terminal \
     && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /workspace corral-terminal
 
 WORKDIR /opt/corral
 COPY . /opt/corral
-RUN python -m pip install --no-cache-dir .
+RUN python -m pip install --no-cache-dir -e .
 
 VOLUME ["/workspace"]
 CMD ["corral", "--help"]

--- a/docker/wetlab.Dockerfile
+++ b/docker/wetlab.Dockerfile
@@ -3,9 +3,6 @@ FROM condaforge/miniforge3:latest
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-RUN groupadd --gid 10001 corral-terminal \
-    && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /workspace corral-terminal
-
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
@@ -19,7 +16,8 @@ ENV PATH=/opt/conda/envs/wetlab/bin:$PATH
 
 WORKDIR /opt/corral
 COPY . /opt/corral
-RUN pip install --no-cache-dir --editable . --editable tasks/wetlab
+RUN pip install --no-cache-dir --editable . --editable tasks/wetlab \
+    && python -m corral.runtime.permissions --prepare-image
 
 VOLUME ["/workspace"]
 CMD ["corral", "--help"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,9 +110,13 @@ claude = ["claude-agent-sdk==0.2.115"]
 # Keep the SDK and its native tool package on the same release. The adapter uses
 # OpenHands' default terminal/file-editor/task-tracker/browser preset in addition
 # to the task-scoped Corral MCP endpoint.
+# Chromium is a separate download; Python extras cannot run post-install hooks.
+# Install this extra and its browser together from the repository root with:
+# uv run --extra openhands python -m playwright install chromium --with-deps --no-shell
 openhands = [
   "openhands-sdk==1.35.0; python_version >= '3.12'",
   "openhands-tools==1.35.0; python_version >= '3.12'",
+  "playwright>=1.49.0,<2; python_version >= '3.12'",
 ]
 irt = [
     "pymc>=5.0.0",

--- a/src/corral/agents/ai_scientist/agent.py
+++ b/src/corral/agents/ai_scientist/agent.py
@@ -76,7 +76,9 @@ def _call_llm_from_harness(portal: BlockingPortal, **call_kwargs: Any) -> Any:
 
 
 class _BranchSessionRegistry:
-    """Create logical/physical AI Scientist branches from a commit projection."""
+    """Give each physical node a private directory inside the trial workspace."""
+
+    isolated_node_workspaces = True
 
     def __init__(self, parent: AgentSession, portal: BlockingPortal) -> None:
         self.parent = parent
@@ -91,7 +93,13 @@ class _BranchSessionRegistry:
         source: AgentSession,
     ) -> BranchSessionHandle:
         execution_id = f"{self.parent.execution_id}-scientist-{uuid4()}"
-        session = self.portal.call(partial(source.fork_branch, branch_id=execution_id))
+        session = self.portal.call(
+            partial(
+                source.fork_branch,
+                branch_id=execution_id,
+                workspace_parent=self.execution_workspace,
+            )
+        )
         with self._lock:
             self._sessions[execution_id] = session
         return BranchSessionHandle(
@@ -113,6 +121,17 @@ class _BranchSessionRegistry:
             session = self._sessions.pop(execution_id, None)
         if session is not None:
             session.environment.shutdown_jobs()
+
+    def promote_branch_artifacts(
+        self, source_execution_id: str, destination_execution_id: str
+    ) -> dict[str, Any]:
+        if destination_execution_id != self.execution_id:
+            raise ValueError("artifacts must be promoted to the owning execution")
+        source = self.session(source_execution_id)
+        files = self.portal.call(
+            partial(self.parent.promote_artifacts, source_workspace=source.workspace)
+        )
+        return {"files": files}
 
     def session(self, execution_id: str) -> AgentSession:
         with self._lock:

--- a/src/corral/agents/ai_scientist/prompts/__init__.py
+++ b/src/corral/agents/ai_scientist/prompts/__init__.py
@@ -1,10 +1,17 @@
 """Packaged prompt loading with deliberately small templating semantics."""
 
+from functools import cache, lru_cache
 from importlib.resources import files
 
 
+@cache
+def load_prompt(name: str) -> str:
+    """Load a template before entering a restricted worker identity."""
+    return files(__package__).joinpath(f"{name}.md").read_text(encoding="utf-8")
+
+
 def render_prompt(name: str, **values: object) -> str:
-    prompt = files(__package__).joinpath(f"{name}.md").read_text(encoding="utf-8")
+    prompt = load_prompt(name)
     for key, value in values.items():
         prompt = prompt.replace("{{" + key + "}}", str(value))
     return prompt

--- a/src/corral/agents/ai_scientist/prompts/experiment_step.md
+++ b/src/corral/agents/ai_scientist/prompts/experiment_step.md
@@ -31,7 +31,10 @@ arguments, purpose, and expected information when another measurement would
 advance this experiment. Return `decision="finish"`, no action fields, and a
 brief evidence-grounded conclusion when the experiment is complete or no
 useful action remains. Keep output paths relative to the node's branch
-workspace. Do not call scoring or answer-submission tools.
+workspace (`branch_workspace` above), even if the task prompt names the enclosing
+trial workspace. Starting files have been copied into this directory. Other
+nodes' directories and the main agent's files are not accessible from your tools.
+Do not call scoring or answer-submission tools.
 Unless the experiment node says `physical_state_inherited=true`, parent results
 are scientific context only: reproduce every state/configuration needed for
 this experiment in the clean trial instead of assuming the parent's live tool

--- a/src/corral/agents/ai_scientist/tools/execution_pool.py
+++ b/src/corral/agents/ai_scientist/tools/execution_pool.py
@@ -102,6 +102,9 @@ class ExecutionPool:
         replay_equivalence: ReplayEquivalence | None = None,
     ) -> None:
         self.sessions = sessions
+        self.isolated_node_workspaces = getattr(
+            sessions, "isolated_node_workspaces", False
+        )
         self.tools = tools
         self.max_observation_chars = max_observation_chars
         self.stop_on_error = stop_on_error
@@ -205,6 +208,12 @@ class ExecutionPool:
         """Get a runtime at `parent`, cloning or replaying when needed."""
         if parent is None:
             return self.create()
+        if self.isolated_node_workspaces:
+            return (
+                self._clone(parent, tree)
+                if self.can_clone(parent)
+                else self._fork(parent, tree)
+            )
         if prefer_existing and parent.branch_id is not None:
             existing = self.active.get(parent.branch_id)
             if existing is not None and existing.head_node_id == parent.id:
@@ -224,6 +233,12 @@ class ExecutionPool:
         """Return physical calls needed to place a runtime at `parent`."""
         if parent is None:
             return 0
+        if self.isolated_node_workspaces:
+            return (
+                0
+                if self.can_clone(parent)
+                else len(tree.executed_trajectory(parent.id))
+            )
         if prefer_existing and parent.branch_id is not None:
             existing = self.active.get(parent.branch_id)
             if existing is not None and existing.head_node_id == parent.id:

--- a/src/corral/agents/hooks/core.py
+++ b/src/corral/agents/hooks/core.py
@@ -51,12 +51,11 @@ class HookContext:
     @property
     def task_id(self) -> str:
         """Return the projected task ID, falling back to execution ID."""
-        value = self.session.state.task.metadata.get("id")
-        return str(value or self.session.execution_id)
+        return self.session.task_id
 
     @property
     def state(self) -> ExecutionState:
-        """Return the session's current immutable projection."""
+        """Return the local projection; unavailable in restricted agent workers."""
         return self.session.state
 
     @property

--- a/src/corral/agents/llm_planner.py
+++ b/src/corral/agents/llm_planner.py
@@ -52,6 +52,14 @@ class LLMPlanner(BaseAgent):
             temperature=temperature,
             **kwargs,
         )
+        # Load the delegate's prompts before Docker workers lose source access.
+        # ReAct keeps execution state in the session, so the delegate is reusable.
+        self._executor = ReActAgent(
+            model=self.model,
+            api_endpoint=self.api_endpoint,
+            temperature=self.temperature,
+            **self._call_kwargs(),
+        )
 
     async def run_session(self, session: AgentSession) -> AgentOutcome:
         """Own planning and delegate low-level actions through the same session."""
@@ -154,12 +162,7 @@ class LLMPlanner(BaseAgent):
                 )
             )
         )
-        executor = ReActAgent(
-            model=self.model,
-            api_endpoint=self.api_endpoint,
-            temperature=self.temperature,
-            **self._call_kwargs(),
-        )
+        executor = self._executor
         outcome = await session.run_delegate(
             executor,
             max_iterations=remaining_iterations,

--- a/src/corral/agents/openhands.py
+++ b/src/corral/agents/openhands.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import os
 import platform
 import shutil
@@ -20,8 +21,8 @@ try:
         LLM,
         Agent,
         AgentContext,
-        Conversation,
         LLMConvertibleEvent,
+        LocalConversation,
     )
     from openhands.sdk.conversation.state import ConversationExecutionStatus
     from openhands.sdk.event import (
@@ -32,8 +33,11 @@ try:
     )
     from openhands.sdk.event.conversation_error import ConversationErrorEvent
     from openhands.sdk.mcp import MCPServer
+    from openhands.sdk.mcp.client import MCPClient
+    from openhands.sdk.mcp.config import to_fastmcp_mcp_config
     from openhands.sdk.mcp.exceptions import MCPError
-    from openhands.sdk.mcp.tool import MCP_TOOL_TIMEOUT_SECONDS
+    from openhands.sdk.mcp.tool import MCP_TOOL_TIMEOUT_SECONDS, MCPToolExecutor
+    from openhands.sdk.mcp.utils import _connect_and_list_tools, log_handler
     from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, FinishAction
     from openhands.tools.preset.default import get_default_tools
 except ModuleNotFoundError as exc:  # pragma: no cover - exercised via extras
@@ -60,15 +64,47 @@ _MCP_SERVER_NAME = "corral"
 # from `openhands.tools.preset.default.get_default_tools()` at agent build time.
 _INCLUDED_DEFAULT_TOOLS = [tool.__name__ for tool in BUILT_IN_TOOLS]
 
-# OpenHands 1.35.0 caps every MCP tool call at a fixed *executor* timeout and
-# does NOT propagate `MCPServer.timeout` into that executor — the server-level
-# timeout only bounds the HTTP transport, while `MCPToolExecutor` wraps each call
-# in its own `MCP_TOOL_TIMEOUT_SECONDS` deadline and cancels first. So a per-call
-# timeout above this cap cannot actually be honored. The value is read from the
-# installed SDK (rather than hard-coded) so the recorded provenance tracks the
-# pinned version, and `tool_timeout_s` defaults to it so the configured timeout
-# is enforceable end-to-end out of the box.
-_OPENHANDS_EXECUTOR_TIMEOUT_S = float(MCP_TOOL_TIMEOUT_SECONDS)
+# Twice the longest successful silicon_melting_1 tool call (600.556482 s),
+# rounded up. Includes the simulation and workspace synchronization.
+_DEFAULT_TOOL_TIMEOUT_S = 1202.0
+_OPENHANDS_DEFAULT_EXECUTOR_TIMEOUT_S = float(MCP_TOOL_TIMEOUT_SECONDS)
+
+
+class _TimeoutMCPToolProvider:
+    """Apply the per-run deadline to Corral's MCP client and tool executors.
+
+    OpenHands 1.35.0 does not pass MCPServer.timeout into either the FastMCP
+    client or its executors. Use its local-conversation provider hook instead
+    of changing SDK globals, so concurrent agents can have different limits.
+    """
+
+    def __init__(self, tool_timeout_s: float):
+        self.tool_timeout_s = tool_timeout_s
+
+    def create_tools(
+        self, mcp_config: dict[str, MCPServer], timeout: float = 30.0
+    ) -> MCPClient:
+        client = MCPClient(
+            to_fastmcp_mcp_config(mcp_config),
+            timeout=self.tool_timeout_s,
+            log_handler=log_handler,
+        )
+        try:
+            # Keep the SDK's connection/listing deadline separate from the
+            # potentially much longer simulation deadline. This pinned-SDK
+            # helper performs its normal schema conversion and registration.
+            client.call_async_from_sync(
+                _connect_and_list_tools, timeout=timeout, client=client
+            )
+            for tool in client.tools:
+                if not isinstance(tool.executor, MCPToolExecutor):
+                    raise TypeError(f"Unexpected MCP executor for {tool.name}")
+                tool.executor.timeout = self.tool_timeout_s
+        except BaseException:
+            client.sync_close()
+            raise
+        return client
+
 
 # Pinned agent identity, forwarded as `Agent.system_prompt_kwargs["soul_content"]`
 # so the system prompt cannot silently inherit a machine-local
@@ -187,15 +223,10 @@ class OpenHandsAgent(BaseAgent):
             harness `LLM` (`"low"`, `"medium"`, `"high"`, `"xhigh"`, or
             `"none"`). If None, the OpenHands SDK default (`"high"`) applies and
             the value is left unset on the `LLM`. Defaults to None.
-        tool_timeout_s (float, optional): MCP transport (HTTP request) timeout
-            passed to `MCPServer.timeout`. NOTE: OpenHands separately caps each
-            MCP tool *call* at a fixed executor timeout
-            (`MCP_TOOL_TIMEOUT_SECONDS`) that `MCPServer.timeout` does not
-            override, so the effective per-call ceiling is
-            `min(tool_timeout_s, executor cap)`. Values above the cap are honored
-            only at the transport layer and log a warning. Defaults to the
-            executor cap (300) so the configured timeout is enforceable
-            end-to-end.
+        tool_timeout_s (float, optional): Per-tool timeout in seconds, applied
+            to both the MCP client's HTTP/session reads and the SDK tool
+            executor. Must be finite and positive. Defaults to 1202 seconds
+            (twice the longest measured successful silicon MD call, rounded up).
         system_prompt (str, optional): Instructions appended to the OpenHands
             harness system prompt (via `AgentContext.system_message_suffix`). If
             None, uses the default corral system prompt. Tool-usage and
@@ -217,7 +248,7 @@ class OpenHandsAgent(BaseAgent):
         temperature: float = 0.7,
         reasoning_effort: Literal["low", "medium", "high", "xhigh", "none"]
         | None = None,
-        tool_timeout_s: float = _OPENHANDS_EXECUTOR_TIMEOUT_S,
+        tool_timeout_s: float = _DEFAULT_TOOL_TIMEOUT_S,
         system_prompt: str | None = None,
         user_prompt: str | None = None,
         surrender_prompt: str | None = None,
@@ -232,6 +263,8 @@ class OpenHandsAgent(BaseAgent):
             )
         if user_prompt is None:
             user_prompt = "tool_calling/user_prompt"
+        if not math.isfinite(tool_timeout_s) or tool_timeout_s <= 0:
+            raise ValueError("tool_timeout_s must be finite and positive")
 
         super().__init__(
             model=model,
@@ -248,20 +281,7 @@ class OpenHandsAgent(BaseAgent):
         self.api_key = api_key
         self.reasoning_effort = reasoning_effort
         self.tool_timeout_s = tool_timeout_s
-        # OpenHands caps each MCP call at its own executor timeout regardless of
-        # `MCPServer.timeout`, so the value actually enforced per call is the
-        # smaller of the two. Warn loudly when a caller asks for more than the
-        # SDK can honor rather than silently under-delivering.
-        if tool_timeout_s > _OPENHANDS_EXECUTOR_TIMEOUT_S:
-            logger.warning(
-                f"tool_timeout_s={tool_timeout_s}s exceeds the OpenHands MCP "
-                f"executor cap of {_OPENHANDS_EXECUTOR_TIMEOUT_S}s; OpenHands does "
-                "not propagate MCPServer.timeout into its executor, so each MCP "
-                f"call will still be cancelled after {_OPENHANDS_EXECUTOR_TIMEOUT_S}s."
-            )
-        self.effective_tool_timeout_s = min(
-            tool_timeout_s, _OPENHANDS_EXECUTOR_TIMEOUT_S
-        )
+        self.effective_tool_timeout_s = tool_timeout_s
 
     def _system_message_suffix(self, enable_surrender: bool) -> str:
         """Compose the suffix appended to the OpenHands harness system prompt.
@@ -313,14 +333,27 @@ class OpenHandsAgent(BaseAgent):
             llm_kwargs["base_url"] = self.api_endpoint
         return LLM(**llm_kwargs)
 
-    def _build_agent(self, llm: Any, mcp_url: str, enable_surrender: bool) -> Any:
+    def _build_agent(
+        self,
+        llm: Any,
+        mcp_url: str,
+        enable_surrender: bool,
+        mcp_tool_names: set[str] | None = None,
+    ) -> Any:
         """Assemble the reproducible OpenHands `Agent` for a run."""
+        # Docker provides a task-scoped terminal through MCP. The SDK rejects
+        # duplicate tool names, so prefer the task capability when it overlaps
+        # with a native tool, while retaining the rest of the standard preset.
+        task_tools = mcp_tool_names or set()
+        native_tools = [
+            tool for tool in get_default_tools() if tool.name not in task_tools
+        ]
         return Agent(
             llm=llm,
             # Use the SDK-owned standard preset (terminal, file editor, task
             # tracker, and browser) so Corral follows OpenHands defaults as the
             # SDK evolves. Core Finish/Think tools are included by Agent itself.
-            tools=get_default_tools(),
+            tools=native_tools,
             mcp_config={
                 _MCP_SERVER_NAME: MCPServer(
                     url=mcp_url,
@@ -378,13 +411,10 @@ class OpenHandsAgent(BaseAgent):
             "run_limit_policy": "iterations_only",
             "stuck_detection_enabled": False,
             "streaming_enabled": True,
-            # Timeout provenance, named for what OpenHands actually enforces. The
-            # configured value is the MCP transport (HTTP request) timeout passed
-            # to `MCPServer.timeout`; per-call execution is separately capped by
-            # the SDK's fixed executor timeout, which `MCPServer.timeout` does not
-            # override. The effective per-call ceiling is the smaller of the two.
+            # The provider applies the requested value to both timeout layers.
             "configured_mcp_timeout_s": self.tool_timeout_s,
-            "openhands_executor_timeout_s": _OPENHANDS_EXECUTOR_TIMEOUT_S,
+            "openhands_executor_timeout_s": self.tool_timeout_s,
+            "openhands_default_executor_timeout_s": _OPENHANDS_DEFAULT_EXECUTOR_TIMEOUT_S,
             "effective_tool_timeout_s": self.effective_tool_timeout_s,
             "mcp_url": mcp_url,
             "tool_verbosity": verbosity,
@@ -649,9 +679,21 @@ class OpenHandsAgent(BaseAgent):
                 )
 
         llm = self._make_llm()
-        agent = self._build_agent(llm, mcp_url, enable_surrender=enable_surrender)
-        conversation = Conversation(
+        agent = self._build_agent(
+            llm,
+            mcp_url,
+            enable_surrender=enable_surrender,
+            mcp_tool_names={
+                tool["function"]["name"]
+                for tool in run.available_tools
+                if tool.get("function", {}).get("name")
+            },
+        )
+        # The generic Conversation factory in SDK 1.35.0 does not expose the
+        # provider hook. This adapter always uses a local workspace.
+        conversation = LocalConversation(
             agent=agent,
+            mcp_tool_provider=_TimeoutMCPToolProvider(self.tool_timeout_s),
             callbacks=[on_event],
             # OpenHands deliberately falls back to a blocking response when
             # streaming is enabled without a token callback. A no-op callback

--- a/src/corral/agents/reflexion_agent.py
+++ b/src/corral/agents/reflexion_agent.py
@@ -76,7 +76,7 @@ class ReflexionAgent(BaseAgent):
 
     def _reflection_module(self, session: AgentSession) -> ReflectionModule:
         """Build a run-local reflection client from projection metadata."""
-        raw_model = session.state.task.model.get("name")
+        raw_model = session.model_name
         if not isinstance(raw_model, str) or not raw_model.strip():
             raise ValueError(
                 "ReflexionAgent requires ExecutionState.task.model.name to be a "
@@ -117,23 +117,7 @@ class ReflexionAgent(BaseAgent):
     @staticmethod
     def _trajectory_from_state(session: AgentSession) -> list[dict[str, Any]]:
         """Read the evaluated attempt's canonical projected transcript."""
-        previous_state = session.previous_state
-        if previous_state is None:
-            return []
-        run = next(
-            (
-                candidate
-                for candidate in previous_state.agent_runs.values()
-                if candidate.actor_id == session.actor.actor_id
-            ),
-            None,
-        )
-        if run is None:
-            return []
-        return [
-            dict(message)
-            for message in previous_state.conversations.get(run.run_id, ())
-        ]
+        return [dict(message) for message in session.previous_messages]
 
     @staticmethod
     async def _store_memory(
@@ -143,18 +127,13 @@ class ReflexionAgent(BaseAgent):
         reflection_model: str,
         actor_status: str | None = None,
     ) -> None:
-        previous_state = session.previous_state
         await session.set_agent_state(
             _REFLEXION_STATE_NAMESPACE,
             {
                 "schema_version": 1,
                 "reflection_model": reflection_model,
                 "memory": memory.to_dict(),
-                "source_commit_hash": (
-                    previous_state.through_commit_hash
-                    if previous_state is not None
-                    else None
-                ),
+                "source_commit_hash": session.previous_commit_hash,
                 "actor_status": actor_status,
             },
         )

--- a/src/corral/agents/session.py
+++ b/src/corral/agents/session.py
@@ -1120,7 +1120,9 @@ class AgentSession:
         )
         environment = self.environment.for_task(f"{self.execution_id}:{selected}")
         branch_state = await self.state_store.materialize(selected)
-        environment.prepare_workspace(branch_state.workspace)
+        await anyio.to_thread.run_sync(
+            environment.prepare_workspace, branch_state.workspace
+        )
         return AgentSession(
             environment,
             branch_state,
@@ -1322,7 +1324,7 @@ async def run_agent_session(
     mcp_host: MCPHost | None = None,
 ) -> AgentSessionOutcome:
     """Run an agent, borrowing a caller-owned host if it or its children use MCP."""
-    environment.prepare_workspace(state.workspace)
+    await anyio.to_thread.run_sync(environment.prepare_workspace, state.workspace)
     interface = AgentSession(
         environment,
         state,

--- a/src/corral/agents/session.py
+++ b/src/corral/agents/session.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from uuid import NAMESPACE_URL, uuid4, uuid5
 
@@ -26,12 +27,15 @@ from corral.core.events import (
     AgentStateUpdated,
     AgentTurnRecorded,
     ContextImported,
+    EnvironmentOperation,
     ParallelGroupCompleted,
     SubmissionAccepted,
+    TaskConfigured,
     ToolCompleted,
     ToolFailed,
     ToolStarted,
     UsageDelta,
+    WorkspaceDelta,
 )
 from corral.core.state import ExecutionState, UsageState
 from corral.core.tool import ToolConnection, ToolResponse
@@ -39,6 +43,7 @@ from corral.core.tool_catalog import ToolCatalogSnapshot
 from corral.core.transition import ToolEffects, execute_action, propose_action
 from corral.observability import record_commit_safely
 from corral.persistence import CommitConflictError
+from corral.runtime import permissions
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -106,7 +111,7 @@ def inspect_subagent_tool() -> dict[str, Any]:
         "function": {
             "name": INSPECT_SUBAGENT_TOOL_NAME,
             "description": (
-                "Inspect the private context and execution state of a child or "
+                "Inspect the conversation and tool activity of a child or "
                 "descendant subagent that this agent is authorized to inspect. "
                 "Use this only when the normal subagent result needs investigation."
             ),
@@ -120,7 +125,10 @@ def inspect_subagent_tool() -> dict[str, Any]:
                     "include_commits": {
                         "type": "boolean",
                         "default": False,
-                        "description": "Include recent authored commit records.",
+                        "description": (
+                            "Include recent authored commit records when permitted; "
+                            "unavailable in Docker workers."
+                        ),
                     },
                     "limit": {
                         "type": "integer",
@@ -393,6 +401,36 @@ class AgentSession:
     def previous_evaluation(self) -> Mapping[str, Any] | None:
         return dict(self._last_score) if isinstance(self._last_score, Mapping) else None
 
+    @property
+    def model_name(self) -> str | None:
+        value = self.state.task.model.get("name")
+        return value if isinstance(value, str) else None
+
+    @property
+    def previous_commit_hash(self) -> str | None:
+        return (
+            self.previous_state.through_commit_hash
+            if self.previous_state is not None
+            else None
+        )
+
+    @property
+    def previous_messages(self) -> tuple[Mapping[str, JsonValue], ...]:
+        """The same agent's prior conversation, without the prior projection."""
+        if self.previous_state is None:
+            return ()
+        run = next(
+            (
+                candidate
+                for candidate in self.previous_state.agent_runs.values()
+                if candidate.actor_id == self.actor.actor_id
+            ),
+            None,
+        )
+        if run is None:
+            return ()
+        return self.previous_state.conversations.get(run.run_id, ())
+
     def _run_state(
         self, state: ExecutionState, *, previous: bool
     ) -> Mapping[str, Mapping[str, JsonValue]] | None:
@@ -589,9 +627,15 @@ class AgentSession:
             },
         }
         if include_commits:
-            observation["commits"] = [
-                commit.model_dump(mode="json") for commit in trace.commits[-limit:]
-            ]
+            # ToolCompleted commits carry private environment operations. Keep
+            # them controller-side even when an agent asks for its child's trace.
+            observation["commits"] = (
+                []
+                if permissions.enabled()
+                else [
+                    commit.model_dump(mode="json") for commit in trace.commits[-limit:]
+                ]
+            )
         return ToolEffects(observation=observation, status="success")
 
     async def _run_tool(
@@ -1111,19 +1155,45 @@ class AgentSession:
             f"agent:{self.actor.run_id}:import:{child_run_id}:{uuid4()}",
         )
 
-    async def fork_branch(self, *, branch_id: str | None = None) -> AgentSession:
+    async def fork_branch(
+        self, *, branch_id: str | None = None, workspace_parent: str | None = None
+    ) -> AgentSession:
+        """Fork state into a separate workspace, optionally nested under its owner."""
         selected = branch_id or f"experiment-{uuid4()}"
+        node_workspace = None
+        if workspace_parent is not None:
+            if self.workspace is None:
+                raise ValueError("node branches require a workspace")
+            node_workspace = await anyio.to_thread.run_sync(
+                permissions.create_node_workspace, workspace_parent, self.workspace
+            )
         await self.state_store.create_branch(
             branch_id=selected,
             from_hash=self._last_observed_hash,
             execution_id=self.execution_id,
         )
-        environment = self.environment.for_task(f"{self.execution_id}:{selected}")
-        branch_state = await self.state_store.materialize(selected)
-        await anyio.to_thread.run_sync(
-            environment.prepare_workspace, branch_state.workspace
+        environment = self.environment.for_task(
+            f"{self.execution_id}:{selected}",
+            **({"workspace_path": node_workspace} if node_workspace else {}),
         )
-        return AgentSession(
+        if (
+            getattr(self.environment.tools.get("terminal"), "worker_operation", None)
+            == "terminal"
+        ):
+            from corral.workspace import (
+                WorkspaceFilesystem,
+                build_terminal_tool,
+            )
+
+            environment.tools["terminal"] = build_terminal_tool(
+                WorkspaceFilesystem(environment.workspace_path)
+            )
+        branch_state = await self.state_store.materialize(selected)
+        if node_workspace is None:
+            await anyio.to_thread.run_sync(
+                environment.prepare_workspace, branch_state.workspace
+            )
+        branch = AgentSession(
             environment,
             branch_state,
             actor=self.actor,
@@ -1137,6 +1207,48 @@ class AgentSession:
             hooks=self._hooks,
             agent=self._hook_agent,
             mcp_host=self.mcp_host,
+        )
+        if node_workspace is not None:
+            workspace = await environment.workspace_manager.snapshot(
+                node_workspace, previous=branch_state.workspace
+            )
+            workspace_args = {
+                name
+                for tool in environment.tools.values()
+                for name in getattr(tool, "workspace_args", ())
+            }
+            commit = await branch._append_runtime(
+                TaskConfigured(
+                    status="Node workspace prepared",
+                    workspace_delta=WorkspaceDelta.from_workspace(workspace),
+                    expected_workspace_revision=branch_state.workspace.revision,
+                    environment_operations=tuple(
+                        EnvironmentOperation(
+                            operation="set",
+                            path=("hidden_arguments", name),
+                            value=node_workspace,
+                        )
+                        for name in sorted(workspace_args)
+                    ),
+                    expected_environment_revision=branch_state.environment.revision,
+                ),
+                f"branch:{selected}:workspace",
+            )
+            await branch._refresh(observed_hash=commit.hash)
+        return branch
+
+    async def promote_artifacts(self, *, source_workspace: str) -> list[str]:
+        """Copy a selected node's files into this agent's canonical workspace."""
+        if self.workspace is None:
+            raise ValueError("artifact promotion requires a workspace")
+        source = Path(source_workspace)
+        nodes = Path(self.workspace) / permissions.NODE_WORKSPACE_DIR
+        if source.parent != nodes or ".." in source.parts:
+            raise PermissionError(
+                "only this workspace's node artifacts may be promoted"
+            )
+        return await anyio.to_thread.run_sync(
+            permissions.copy_workspace, source, self.workspace
         )
 
     def final_messages(self) -> tuple[Mapping[str, JsonValue], ...]:
@@ -1190,7 +1302,7 @@ def _enforce_tool_submission(
 ) -> AgentOutcome:
     if not interface._require_submission:
         return result
-    submission = interface.state.submission
+    submission = interface.submission
     if submission is None:
         if result.status not in {"completed", "surrendered"}:
             return result
@@ -1201,9 +1313,7 @@ def _enforce_tool_submission(
             metadata=result.metadata,
         )
     expected_status = (
-        "surrendered"
-        if interface.state.runtime.status == "surrendered"
-        else "completed"
+        "surrendered" if interface.submission_status == "surrendered" else "completed"
     )
     expected_answer = None if expected_status == "surrendered" else submission
     if result.status == expected_status and result.answer == expected_answer:
@@ -1225,10 +1335,20 @@ def _enforce_tool_submission(
 
 async def _run_agent_with_tools(agent: Agent, session: AgentSession) -> AgentOutcome:
     """Borrow the execution host for the duration of this invocation."""
+
+    async def invoke() -> AgentOutcome:
+        if permissions.enabled():
+            from corral.runtime.agent_worker import (  # - broker imports session
+                run_agent,
+            )
+
+            return await run_agent(agent, session)
+        return await agent.run_session(session)
+
     transport = getattr(agent, "tool_transport", "python")
     if transport == "python":
         with session.bind_tool_connection(ToolConnection()):
-            return await agent.run_session(session)
+            return await invoke()
     if transport == "mcp":
         if session.mcp_host is None:
             raise RuntimeError(
@@ -1248,13 +1368,25 @@ async def _run_agent_with_tools(agent: Agent, session: AgentSession) -> AgentOut
             name=f"corral-{session.execution_id}-{session.actor.run_id}",
         ) as connection:
             with session.bind_tool_connection(connection):
-                return await agent.run_session(session)
+                return await invoke()
     raise ValueError(
         f"Unsupported agent tool_transport {transport!r}; expected 'python' or 'mcp'"
     )
 
 
 async def _run_bound_agent(agent: Agent, interface: AgentSession) -> AgentOutcome:
+    if permissions.enabled():
+        result = await _run_agent_with_tools(agent, interface)
+        return _enforce_tool_submission(_normalize_outcome(result), interface)
+    return await _run_agent_lifecycle(
+        agent, interface, lambda: _run_agent_with_tools(agent, interface)
+    )
+
+
+async def _run_agent_lifecycle(
+    agent: Agent, interface: AgentSession, invoke
+) -> AgentOutcome:
+    """Run lifecycle hooks in the same identity as the agent implementation."""
     raw_hooks = getattr(agent, "hooks", None)
     hooks = AgentHooks() if raw_hooks is None else raw_hooks
     if not isinstance(hooks, AgentHooks):
@@ -1282,7 +1414,7 @@ async def _run_bound_agent(agent: Agent, interface: AgentSession) -> AgentOutcom
                 error="agent session cancelled by a before-task hook",
             )
         else:
-            result = await _run_agent_with_tools(agent, interface)
+            result = await invoke()
         if not isinstance(result, AgentOutcome):
             raise TypeError("Agent.run_session() must return AgentOutcome")
         result = _enforce_tool_submission(_normalize_outcome(result), interface)

--- a/src/corral/agents/utils.py
+++ b/src/corral/agents/utils.py
@@ -188,7 +188,7 @@ def _reasoning_tokens(usage: Any) -> int | None:
 async def llm_call(
     model: str,
     messages: list[LiteLLMMessage],
-    temperature: float,
+    temperature: float | None,
     tools: list[dict[str, Any]] | None = None,
     api_endpoint: str | None = None,
     return_usage: bool = True,
@@ -198,13 +198,16 @@ async def llm_call(
     Call LiteLLM with a streaming transport and reconstruct its final response.
 
     Args:
-        model (str): The model to use.
+        model (str): The LiteLLM model route, passed through unchanged.
         messages (list[LiteLLMMessage]): The messages to send to the model.
-        temperature (float): The temperature to use.
-        tools (dict[str, Any], optional): The tools to use. If provided, will use tool calling.
+        temperature (float | None): The temperature to use, or None for the provider default.
+        tools (list[dict[str, Any]], optional): The tools to make available to the model.
         api_endpoint (str, optional): The API endpoint to use. When using VLLM.
         return_usage (bool, optional): If True, includes token usage in metadata. Defaults to True.
         **kwargs: Additional keyword arguments to pass to the LiteLLM API.
+            Configure provider requirements here (e.g. max_tokens, reasoning_effort,
+            thinking, tool_choice, or additional_drop_params). Caller settings are
+            preserved; LiteLLM handles provider translation and validation.
             Streaming is always enabled, even if `stream=False` is supplied.
             If 'logprobs' is True in kwargs, logprobs will be included in response metadata.
 
@@ -216,39 +219,11 @@ async def llm_call(
             "model": model,
             "messages": messages,
             "temperature": temperature,
+            "tools": tools,
             "api_base": api_endpoint,
             **kwargs,
         }
 
-        # GPT-5.6 rejects chat-completions requests that combine function tools
-        # with reasoning controls. The explicit LiteLLM `responses/` route
-        # keeps the configured provider model unchanged while selecting the
-        # endpoint that supports both features. This is also stable across the
-        # range of LiteLLM versions used by the task-specific environments.
-        use_gpt_5_6_responses = (
-            tools is not None
-            and kwargs.get("reasoning_effort") is not None
-            and model.startswith("openai/gpt-5.6")
-        )
-        if use_gpt_5_6_responses:
-            params["model"] = model.replace("openai/", "openai/responses/", 1)
-
-        if "anthropic" in model:
-            params["max_tokens"] = 8192
-
-        # When extended thinking is on (LiteLLM turns `reasoning_effort` into an
-        # Anthropic `thinking` block), Anthropic rejects any `temperature` other
-        # than 1 with a 400. Force it so a reasoning run is not aborted; this also
-        # covers reasoning calls made through this shared LiteLLM helper.
-        if kwargs.get("reasoning_effort") or kwargs.get("thinking"):
-            params["temperature"] = 1
-
-        if tools is not None:
-            params["tools"] = tools
-            # Responses defaults to automatic tool selection. Older LiteLLM
-            # bridges reject the otherwise redundant chat-completions value.
-            if not use_gpt_5_6_responses:
-                params["tool_choice"] = "auto"
         # Always consume the provider response as a stream. Besides making long
         # generations observable at the transport layer, this keeps an active
         # response from looking idle to gateways with read/idle timeouts. Build

--- a/src/corral/backend/executors.py
+++ b/src/corral/backend/executors.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import cloudpickle
 
+from corral.runtime import permissions
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -166,6 +168,18 @@ class ThreadExecutor(_PooledExecutor):
         if cancel.is_set():
             raise JobCancelled(work.job_id)
         return render_result(work.tool.execute(**work.call_arguments))
+
+
+class RestrictedExecutor(_PooledExecutor):
+    """Apply the same private-input boundary to foreground and background tools."""
+
+    def run_tool(self, work: JobWork, cancel: threading.Event) -> str:
+        if cancel.is_set():
+            raise JobCancelled(work.job_id)
+        result = permissions.execute_job(
+            work.tool, work.call_arguments, work.workspace, cancel=cancel
+        )
+        return render_result(result)
 
 
 def _run_cloudpickled(blob: bytes) -> str:

--- a/src/corral/backend/jobs.py
+++ b/src/corral/backend/jobs.py
@@ -17,10 +17,12 @@ from corral.backend.executors import (
     JobCancelled,
     JobExecutor,
     JobWork,
+    RestrictedExecutor,
     ThreadExecutor,
     build_executor,
 )
 from corral.report.logging import event, exception_fields
+from corral.runtime import permissions
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -210,11 +212,19 @@ class JobManager:
         cached so every job of the same kind shares one pool; an injected or
         previously-built executor is reused.
         """
-        name = getattr(tool, "executor", None) or DEFAULT_EXECUTOR
+
+        name = (
+            "restricted"
+            if permissions.enabled()
+            else getattr(tool, "executor", None) or DEFAULT_EXECUTOR
+        )
         with self._executors_guard:
             executor = self._executors.get(name)
             if executor is None:
-                executor = build_executor(name, self._max_concurrency)
+                if permissions.enabled():
+                    executor = RestrictedExecutor(self._max_concurrency)
+                else:
+                    executor = build_executor(name, self._max_concurrency)
                 self._executors[name] = executor
             return executor
 

--- a/src/corral/cli.py
+++ b/src/corral/cli.py
@@ -75,9 +75,6 @@ AGENT_DEFINITIONS: Mapping[str, AgentDefinition] = MappingProxyType(
         "tool-calling": AgentDefinition(
             "corral.agents.tool_calling",
             "ToolCallingAgent",
-            # Provider-native function tools and the reasoning mode enabled by
-            # default for some GPT models cannot be combined reliably.
-            default_kwargs=(("reasoning_effort", "none"),),
         ),
     }
 )
@@ -325,6 +322,8 @@ def _print_results(run_id: str, result: Any) -> None:
                 f"- {task_id} [{trial.trial_id}]: {status}, "
                 f"score={score}, output={output}"
             )
+            if trial.error_message:
+                lines.append(f"  error: {trial.error_message}")
     sys.stdout.write("\n".join(lines) + "\n")
 
 
@@ -617,6 +616,8 @@ async def run_task(args: argparse.Namespace) -> int:
         f"- answer: {answer}\n"
         f"- commit: {state.commit_hash}\n"
     )
+    if state.status == "failed" and state.error:
+        sys.stdout.write(f"- error: {state.error}\n")
     return int(state.status == "failed")
 
 

--- a/src/corral/core/environment.py
+++ b/src/corral/core/environment.py
@@ -231,6 +231,7 @@ class Environment:
         max_job_concurrency: int = DEFAULT_JOB_CONCURRENCY,
         job_executors: dict[str, JobExecutor] | None = None,
         workspace_manager: WorkspaceManager | None = None,
+        workspace_path: str | None = None,
     ):
         self.task_id = task_id
         self.current_task = task
@@ -252,7 +253,7 @@ class Environment:
         # The task orchestrator supplies an opaque execution id solely to
         # namespace materialization. Environment neither derives nor interprets
         # benchmark repetition indices.
-        self.workspace_path = (
+        self.workspace_path = workspace_path or (
             self._create_task_workspace(task_execution_id)
             if task_execution_id is not None and self.base_work_dir
             else None
@@ -403,6 +404,7 @@ class Environment:
         task_execution_id: str,
         *,
         max_job_concurrency: int | None = None,
+        workspace_path: str | None = None,
     ) -> "Environment":
         """Bind this definition to one isolated task execution.
 
@@ -417,6 +419,8 @@ class Environment:
 
         `max_job_concurrency` sizes this task execution's background-job pool;
         `None` falls back to the definition's default.
+        `workspace_path` binds a directory already allocated by the controller,
+        such as a node directory inside the owning trial workspace.
         """
         return type(self)(
             task_id=self.task_id,
@@ -434,6 +438,9 @@ class Environment:
             ),
             job_executors=self.job_executors,
             workspace_manager=self.workspace_manager,
+            **(
+                {"workspace_path": workspace_path} if workspace_path is not None else {}
+            ),
         )
 
     def _create_task_workspace(self, task_execution_id: str) -> str:

--- a/src/corral/core/tool.py
+++ b/src/corral/core/tool.py
@@ -122,10 +122,19 @@ class Tool:
         executor: str | None = None,
         concurrency_key: str | None = None,
         concurrency: "ToolConcurrency | str" = ToolConcurrency.SERIAL,
+        trusted: bool = False,
+        workspace_args: tuple[str, ...] = (),
     ):
         self.name = name
         self.description = description
         self.hidden_args = hidden_args or {}
+        # Docker tools are restricted by default. Only explicitly trusted task
+        # logic may receive private inputs and run in the controller; it must
+        # never evaluate model-supplied code or load workspace executables.
+        self.trusted = trusted
+        self.workspace_args = tuple(workspace_args)
+        if not set(self.workspace_args) <= self.hidden_args.keys():
+            raise ValueError("workspace_args must name hidden arguments")
         # Background-execution metadata (PR 4). A tool marked
         # `background_capable` gets a generated `start_<tool>` variant that runs
         # it as a background job so the agent is not blocked while it runs.
@@ -292,6 +301,8 @@ def tool(
     executor: str | None = None,
     concurrency_key: str | None = None,
     concurrency: "ToolConcurrency | str" = ToolConcurrency.SERIAL,
+    trusted: bool = False,
+    workspace_args: tuple[str, ...] = (),
 ) -> Tool | Callable[[Callable], Tool]:
     """Decorator to convert a function into a Tool.
 
@@ -338,6 +349,12 @@ def tool(
             exclusive (a readers-writer split within one resource).
         concurrency: How this tool may overlap other tool calls in one runtime
             (see :class:`ToolConcurrency`). Defaults to `SERIAL`.
+        trusted: Run task logic with private inputs in the Docker controller.
+            Never enable this for shell, Python, untrusted file-loading, or other tools
+            that execute model-controlled code. Restricted execution is default.
+        workspace_args: Hidden arguments that carry only the assigned workspace
+            path. Docker workers receive a fresh binding from the controller,
+            never the corresponding value from private environment state.
 
     Returns:
         A Tool instance wrapping the function.
@@ -389,6 +406,8 @@ def tool(
                     executor=executor,
                     concurrency_key=concurrency_key,
                     concurrency=concurrency,
+                    trusted=trusted,
+                    workspace_args=workspace_args,
                 )
 
             def execute(self, **kwargs):
@@ -400,7 +419,7 @@ def tool(
                 # complete environment replacement. Preserve that value for
                 # the runtime; ordinary function tools keep their textual tool
                 # result contract.
-                from corral.core.transition import (
+                from corral.core.transition import (  # - avoid import cycle
                     ToolExecutionResult,
                 )
 

--- a/src/corral/core/transition.py
+++ b/src/corral/core/transition.py
@@ -18,6 +18,7 @@ from corral.core.events import (
     WorkspaceDelta,
 )
 from corral.core.tool import ToolCallStatus
+from corral.runtime import permissions
 
 if TYPE_CHECKING:
     from pydantic import JsonValue
@@ -193,6 +194,11 @@ def execute_action(
         if tool is None:
             status = ToolCallStatus.INVALID_TOOL
             content = f"Tool {action.name} not found"
+        elif permissions.enabled() and (
+            error := permissions.visible_argument_error(tool, dict(action.arguments))
+        ):
+            status = ToolCallStatus.INVALID_ARGS
+            content = error
         else:
             visible_arguments = environment.preprocess_arguments(
                 action.name, dict(action.arguments)
@@ -223,8 +229,14 @@ def execute_action(
                         guard = getattr(environment, "execution_guard", None)
                         context = guard(tool) if guard is not None else nullcontext()
                         with context:
-                            raw_result = environment.execute_tool(
-                                state, tool, call_arguments
+                            raw_result = (
+                                permissions.execute_tool(
+                                    environment, state, tool, call_arguments
+                                )
+                                if permissions.enabled()
+                                else environment.execute_tool(
+                                    state, tool, call_arguments
+                                )
                             )
                         if isinstance(raw_result, ToolExecutionResult):
                             content = raw_result.content

--- a/src/corral/orchestration/internal.py
+++ b/src/corral/orchestration/internal.py
@@ -17,6 +17,7 @@ from corral.orchestration.launchers import LocalTaskLauncher
 from corral.orchestration.models import RUNTIME_PROTOCOL_VERSION, RunTaskInput
 from corral.orchestration.registry import RuntimeRegistry
 from corral.persistence import SQLiteCommitStore, WorkspaceManager
+from corral.runtime import permissions
 from corral.workspace import WorkspaceFilesystem, build_terminal_tool
 
 
@@ -122,30 +123,39 @@ async def run_task_from_files(request_file: str | Path, result_file: str | Path)
         )
 
     checkpoint_root = Path(request_file).resolve().parent
-    workspace_snapshots = checkpoint_root / "workspace-snapshots"
-    legacy_snapshots = checkpoint_root / "snapshots"
-    if (
-        not (workspace_snapshots / "latest.json").is_file()
-        and (legacy_snapshots / "latest.json").is_file()
-    ):
-        workspace_snapshots = legacy_snapshots
-    workspace_manager = WorkspaceManager(
-        artifact_root=checkpoint_root / "artifacts",
-        snapshot_root=workspace_snapshots,
-    )
-    store = SQLiteCommitStore(
-        checkpoint_root / "commits.sqlite3",
-        execution_id=request.execution_id,
-        state_snapshot_root=checkpoint_root / "state-snapshots",
-    )
+
     registry: RuntimeRegistry | None = None
+    store: SQLiteCommitStore | None = None
     try:
+        os.chown(checkpoint_root, 0, 0)
+        checkpoint_root.chmod(0o700)
+        permissions.configure(checkpoint_root)
+        workspace_snapshots = checkpoint_root / "workspace-snapshots"
+        legacy_snapshots = checkpoint_root / "snapshots"
+        if (
+            not (workspace_snapshots / "latest.json").is_file()
+            and (legacy_snapshots / "latest.json").is_file()
+        ):
+            workspace_snapshots = legacy_snapshots
+        workspace_manager = WorkspaceManager(
+            artifact_root=checkpoint_root / "artifacts",
+            snapshot_root=workspace_snapshots,
+        )
+        store = SQLiteCommitStore(
+            checkpoint_root / "commits.sqlite3",
+            execution_id=request.execution_id,
+            state_snapshot_root=checkpoint_root / "state-snapshots",
+        )
         if docker.registry_module is not None:
             registry = _registry_from_module(docker.registry_module, request)
         else:
             registry = _built_in_registry(request, workspace_manager=workspace_manager)
         environment = registry.environment(request.environment_id, request.execution_id)
         environment.workspace_manager = workspace_manager
+        if not environment.workspace_path:
+            raise RuntimeError(
+                "Docker permission enforcement requires a task workspace"
+            )
         if environment.workspace_path:
             workspace_path = Path(environment.workspace_path).resolve()
             if not workspace_path.is_relative_to(Path("/workspace")):
@@ -180,7 +190,8 @@ async def run_task_from_files(request_file: str | Path, result_file: str | Path)
     finally:
         if registry is not None:
             registry.close()
-        await store.aclose()
+        if store is not None:
+            await store.aclose()
         _restore_host_ownership(checkpoint_root)
     return 0
 

--- a/src/corral/orchestration/launchers.py
+++ b/src/corral/orchestration/launchers.py
@@ -379,6 +379,9 @@ class DockerTaskLauncher:
             for directory in ("workspace-snapshots", "snapshots")
         )
         _atomic_json(request_path, asdict(request))
+        # Remove the host shard's setgid mode before Docker Desktop mounts it.
+        # macOS bind mounts can reject chmod after the controller takes ownership.
+        shard.chmod(0o700)
 
         container_name, volume_name = self._names(request.execution_id)
         await self._discard_stale(container_name, volume_name)
@@ -410,8 +413,15 @@ class DockerTaskLauncher:
             "--network",
             docker.network,
             "--read-only",
+            "--init",
+            "--user",
+            "0:0",
             "--security-opt",
             "no-new-privileges",
+            # docker-default denies mounts even with SYS_ADMIN; the trusted
+            # bootstrap must construct the worker filesystem before dropping UID.
+            "--security-opt",
+            "apparmor=unconfined",
             "--cap-drop",
             "ALL",
             "--cap-add",
@@ -420,16 +430,20 @@ class DockerTaskLauncher:
             "SETGID",
             "--cap-add",
             "CHOWN",
+            "--cap-add",
+            "DAC_OVERRIDE",
+            "--cap-add",
+            "KILL",
+            "--cap-add",
+            "SYS_ADMIN",
+            "--cap-add",
+            "SYS_CHROOT",
             "--tmpfs",
-            "/tmp:rw,nosuid,nodev,noexec,size=256m",
+            "/tmp:rw,nosuid,nodev,noexec,mode=0700,size=256m",
             "--mount",
             f"type=volume,src={volume_name},dst=/workspace",
             "--mount",
             f"type=bind,src={shard},dst=/corral-state",
-            "--env",
-            f"CORRAL_TERMINAL_UID={self._terminal_identity()[0]}",
-            "--env",
-            f"CORRAL_TERMINAL_GID={self._terminal_identity()[1]}",
             "--env",
             "HOME=/tmp",
             "--env",
@@ -467,6 +481,7 @@ class DockerTaskLauncher:
                     "benchmark_run_id": request.benchmark_run_id,
                     "container_id": container_id,
                     "container_name": container_name,
+                    "permissions_policy": "workspace-root-v1",
                     "cpus": docker.cpus,
                     "execution_id": request.execution_id,
                     "image": docker.image,
@@ -562,14 +577,6 @@ class DockerTaskLauncher:
             with contextlib.suppress(Exception):
                 return int(json.loads(latest.read_text(encoding="utf-8"))["revision"])
         return None
-
-    @staticmethod
-    def _terminal_identity() -> tuple[int, int]:
-        """Choose an unprivileged identity distinct from the host checkpoint owner."""
-        candidate = 10001
-        if candidate in {os.getuid(), os.getgid()}:
-            candidate += 1
-        return candidate, candidate
 
 
 __all__ = [

--- a/src/corral/orchestration/models.py
+++ b/src/corral/orchestration/models.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-RUNTIME_PROTOCOL_VERSION = "1"
+RUNTIME_PROTOCOL_VERSION = "4"
 
 
 class SandboxMode(str, Enum):
@@ -68,6 +68,11 @@ class DockerSandboxSpec:
             raise ValueError("Docker sandbox network cannot be empty")
         if not self.runtime_protocol_version.strip():
             raise ValueError("runtime_protocol_version cannot be empty")
+        if self.runtime_protocol_version != RUNTIME_PROTOCOL_VERSION:
+            raise ValueError(
+                f"Docker trials require runtime protocol {RUNTIME_PROTOCOL_VERSION}; "
+                "rebuild the image to enable the current permission policy"
+            )
         if self.registry_module == "":
             raise ValueError("registry_module cannot be empty")
         for name in self.environment_allowlist:

--- a/src/corral/persistence/workspace.py
+++ b/src/corral/persistence/workspace.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from corral.core.workspace import Artifact, FileRef, WorkspaceState
 from corral.persistence.artifacts import ArtifactStore, LocalArtifactStore
+from corral.runtime import permissions
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping
@@ -102,6 +103,8 @@ class WorkspaceManager:
         files: list[tuple[str, Path]] = []
         for entry in sorted(root.rglob("*")):
             relative = entry.relative_to(root).as_posix()
+            if relative.split("/", 1)[0] == permissions.NODE_WORKSPACE_DIR:
+                continue
             if entry.is_symlink():
                 raise WorkspacePathError(
                     f"workspace cannot contain symbolic links: {relative}"
@@ -116,6 +119,31 @@ class WorkspaceManager:
         return tuple(files)
 
     async def snapshot(
+        self,
+        source: str | Path,
+        *,
+        previous: WorkspaceState | None = None,
+        created_by_action: str | None = None,
+        artifacts: Mapping[str, Artifact | Mapping[str, Any]] | None = None,
+    ) -> WorkspaceState:
+        """Capture workspace bytes without allowing workers to race privileged reads."""
+
+        if permissions.enabled():
+            with permissions.snapshot_source(source) as trusted_source:
+                return await self._snapshot(
+                    trusted_source,
+                    previous=previous,
+                    created_by_action=created_by_action,
+                    artifacts=artifacts,
+                )
+        return await self._snapshot(
+            source,
+            previous=previous,
+            created_by_action=created_by_action,
+            artifacts=artifacts,
+        )
+
+    async def _snapshot(
         self,
         source: str | Path,
         *,

--- a/src/corral/runtime/_permission_worker.py
+++ b/src/corral/runtime/_permission_worker.py
@@ -1,0 +1,121 @@
+"""Trusted bootstrap. No model-controlled callable runs before dropping UID."""
+
+# Optional agent imports must occur only in agent bootstraps.
+# ruff: noqa: PLC0415
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib
+import json
+import os
+import sys
+from contextlib import suppress
+from pathlib import Path
+
+import cloudpickle
+from pydantic import TypeAdapter
+
+from corral.runtime._worker_filesystem import bind_bootstrap_parent, enter_workspace
+from corral.runtime.permissions import DENIED, drop_privileges, private_controller_types
+
+
+def main() -> None:
+    request, descriptor = sys.argv[1:]
+    # This file is written by the root controller in its private directory.
+    with Path(request).open("rb") as stream:
+        kind, payload, uid, gid, workspace, workspace_fd = cloudpickle.load(stream)
+    Path(request).unlink()
+    output = os.fdopen(int(descriptor), "w")
+    os.set_inheritable(output.fileno(), False)
+    if kind == "agent":
+        from corral.agents.ai_scientist.prompts import load_prompt
+        from corral.agents.session import _run_agent_lifecycle
+        from corral.runtime.agent_worker import RemoteSession, _DelegatedAgent
+
+        for template in (
+            Path(__file__)
+            .parents[1]
+            .joinpath("agents/ai_scientist/prompts")
+            .glob("*.md")
+        ):
+            load_prompt(template.stem)
+
+        agent, connection = payload
+        if isinstance(agent, _DelegatedAgent):
+            # Only trusted, installed agent modules may be preloaded as root.
+            # The opaque delegate pickle is decoded AFTER the identity change.
+            for path in Path(__file__).parents[1].joinpath("agents").rglob("*.py"):
+                parts = (
+                    path.relative_to(Path(__file__).parents[2]).with_suffix("").parts
+                )
+                module = ".".join(parts[:-1] if parts[-1] == "__init__" else parts)
+                with suppress(ImportError):
+                    importlib.import_module(module)
+        session = RemoteSession(*connection)
+    elif kind == "tool":
+        tool, arguments = payload
+    elif kind == "terminal":
+        from corral.workspace import WorkspaceFilesystem, build_terminal_tool
+
+        tool = build_terminal_tool(WorkspaceFilesystem(workspace))
+        arguments = payload
+    else:
+        raise ValueError("unknown restricted worker kind")
+    private_controller_types()
+    # Imported runtimes may have started threads. Fork a single-threaded child
+    # so none can retain the original filesystem context across unshare/chroot.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    parent_pid = os.getpid()
+    child = os.fork()
+    if child:
+        output.close()
+        _, status = os.waitpid(child, 0)
+        code = os.waitstatus_to_exitcode(status)
+        os._exit(code if code >= 0 else 128 - code)
+    bind_bootstrap_parent(parent_pid)
+    scratch = enter_workspace(
+        workspace,
+        Path(request).parent / "root",
+        uid,
+        gid,
+        keep_fds={0, 1, 2, output.fileno()},
+        workspace_fd=workspace_fd,
+    )
+    drop_privileges(uid, gid, workspace, scratch=scratch)
+    # Linux clears the parent-death signal when credentials change.
+    bind_bootstrap_parent(parent_pid)
+    try:
+        if kind == "agent":
+            if isinstance(agent, _DelegatedAgent):
+                agent = cloudpickle.loads(base64.b64decode(agent.blob))
+            session._hook_agent = agent
+            session._hooks = getattr(agent, "hooks", None)
+            result = asyncio.run(
+                _run_agent_lifecycle(agent, session, lambda: agent.run_session(session))
+            )
+        else:
+            result = tool.execute(**arguments)
+            from corral.core.transition import ToolExecutionResult
+
+            if isinstance(result, ToolExecutionResult):
+                raise PermissionError(
+                    "restricted tools cannot replace private task state"
+                )
+            result = {"content": result}
+        response = {
+            "ok": True,
+            "result": TypeAdapter(type(result)).dump_python(result, mode="json"),
+        }
+    except PermissionError as exc:
+        response = {"ok": False, "error": f"{DENIED}: {exc.filename or exc}"}
+    except Exception as exc:
+        response = {"ok": False, "error": str(exc)}
+    with output:
+        json.dump(response, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/corral/runtime/_worker_filesystem.py
+++ b/src/corral/runtime/_worker_filesystem.py
@@ -1,0 +1,254 @@
+"""Build a worker-only filesystem before permanently dropping privileges.
+
+The original container root is never mounted in the jail. Runtime mounts live
+under /workspace; conventional runtime paths are aliases into that tree.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import signal
+import sys
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+RUNTIME_ROOT = Path("/workspace/.corral-runtime-system")
+
+_CLONE_NEWNS = 0x00020000
+_MS_RDONLY = 1
+_MS_NOSUID = 2
+_MS_NODEV = 4
+_MS_NOEXEC = 8
+_MS_REMOUNT = 32
+_MS_BIND = 4096
+_MS_REC = 16384
+_MS_PRIVATE = 1 << 18
+
+_PUBLIC_ETC = (
+    "ssl/certs",
+    "pki/tls/certs",
+    "ca-certificates",
+    "alternatives",
+    "resolv.conf",
+    "hosts",
+    "nsswitch.conf",
+    "localtime",
+    "ld.so.cache",
+)
+
+
+def _directory(path: Path, mode: int = 0o755) -> None:
+    if not path.parent.exists():
+        _directory(path.parent)
+    path.mkdir(exist_ok=True)
+    # The controller uses a private umask; runtime ancestors must be traversable.
+    path.chmod(mode)
+
+
+def _runtime_roots() -> tuple[Path, ...]:
+    roots = [Path(name) for name in ("/usr", "/bin", "/sbin", "/lib", "/lib64")]
+    for prefix in (sys.prefix, sys.base_prefix):
+        path = Path(prefix).resolve()
+        if any(path.is_relative_to(root) for root in roots):
+            continue
+        if not path.is_relative_to("/opt") or path.is_relative_to("/opt/corral"):
+            raise RuntimeError(f"unsupported worker Python installation: {path}")
+        roots.append(path)
+    return tuple(path for path in roots if path.exists())
+
+
+def bind_bootstrap_parent(parent_pid: int) -> None:
+    """Kill this child if its trusted bootstrap is cancelled or exits."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, signal.SIGKILL, 0, 0, 0):  # PR_SET_PDEATHSIG
+        raise OSError(ctypes.get_errno(), "cannot bind worker to its bootstrap")
+    # The parent may have exited before prctl installed the death signal.
+    if os.getppid() != parent_pid:
+        os.kill(os.getpid(), signal.SIGKILL)
+
+
+def enter_workspace(
+    workspace: str,
+    jail: Path,
+    uid: int,
+    gid: int,
+    *,
+    keep_fds: set[int],
+    workspace_fd: int | None = None,
+) -> str:
+    """Relocate the runtime and workspace into a private, read-only root.
+
+    Must run in a freshly forked bootstrap: unshare changes the calling thread's
+    filesystem context, so pre-existing threads must not survive this boundary.
+    No supplied callable is invoked here, and no workspace file is executed.
+    """
+    if len(list(Path("/proc/self/task").iterdir())) != 1:
+        raise RuntimeError(
+            "worker filesystem setup requires a single-threaded bootstrap"
+        )
+    roots = _runtime_roots()
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.mount.argtypes = (
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_char_p,
+        ctypes.c_ulong,
+        ctypes.c_char_p,
+    )
+
+    def mount(source, target, filesystem=None, flags=0, options=None):
+        arguments = (
+            None if source is None else os.fsencode(source),
+            os.fsencode(target),
+            None if filesystem is None else os.fsencode(filesystem),
+            flags,
+            None if options is None else os.fsencode(options),
+        )
+        if libc.mount(*arguments):
+            raise OSError(
+                ctypes.get_errno(), "cannot construct worker filesystem", str(target)
+            )
+
+    def bind(source: Path, target: Path, *, readonly: bool) -> None:
+        if source.is_dir():
+            _directory(target)
+        else:
+            _directory(target.parent)
+            target.touch()
+        # Deliberately do not import nested mounts from the original image.
+        mount(source, target, flags=_MS_BIND)
+        if readonly:
+            mount(
+                None,
+                target,
+                flags=_MS_BIND | _MS_REMOUNT | _MS_RDONLY | _MS_NOSUID | _MS_NODEV,
+            )
+
+    if libc.unshare(_CLONE_NEWNS):
+        raise OSError(ctypes.get_errno(), "cannot create worker mount namespace")
+    mount(None, "/", flags=_MS_REC | _MS_PRIVATE)
+    _directory(jail, 0o700)
+    mount("tmpfs", jail, "tmpfs", _MS_NOSUID | _MS_NODEV, "mode=0755,size=16m")
+    runtime = jail / RUNTIME_ROOT.relative_to("/")
+    _directory(runtime)
+    _directory(jail / "workspace", 0o711)
+
+    # These trees contain the installed OS/Python/SDK dependencies. Corral and
+    # task packages are installed privately at /opt/corral, outside every mount.
+    for source in roots:
+        target = runtime / source.relative_to("/")
+        _directory(target.parent)
+        if source.is_symlink():
+            target.symlink_to(RUNTIME_ROOT / source.resolve().relative_to("/"))
+        else:
+            bind(source, target, readonly=True)
+
+    etc = runtime / "etc"
+    _directory(etc)
+    for name in _PUBLIC_ETC:
+        source = Path("/etc") / name
+        if not source.exists():
+            continue
+        target = etc / name
+        # Only certificate and runtime configuration is published, never the
+        # rest of /etc (including passwords, private keys, and application data).
+        for parent in reversed(target.parents):
+            if parent.is_relative_to(etc):
+                _directory(parent)
+        bind(source.resolve(), target, readonly=True)
+
+    target_workspace = jail / Path(workspace).relative_to("/")
+    for parent in reversed(target_workspace.parents):
+        if parent.is_relative_to(jail / "workspace"):
+            _directory(parent, 0o711)
+    # Pin the controller-validated directory across concurrent renames by the
+    # main agent. Mount from a verified descriptor, not a model-writable path.
+    from corral.runtime.permissions import _open_directory
+
+    # Bind sources must belong to the new mount namespace. Reopen with
+    # O_NOFOLLOW and verify the inode against the controller's pinned handle.
+    local_fd = _open_directory(workspace)
+    try:
+        if workspace_fd is not None:
+            expected, actual = os.fstat(workspace_fd), os.fstat(local_fd)
+            if (expected.st_dev, expected.st_ino) != (actual.st_dev, actual.st_ino):
+                raise PermissionError(
+                    "assigned workspace was replaced during bootstrap"
+                )
+        bind(Path(f"/proc/self/fd/{local_fd}"), target_workspace, readonly=False)
+    finally:
+        os.close(local_fd)
+    scratch_path = Path(
+        tempfile.mkdtemp(prefix=".corral-runtime-", dir=target_workspace)
+    )
+    os.chown(scratch_path, uid, gid)
+    scratch = str(Path(workspace) / scratch_path.name)
+    shared_memory = scratch_path / "shm"
+    shared_memory.mkdir()
+    os.chown(shared_memory, uid, gid)
+
+    # A fresh procfs hides other worker/controller identities. In particular,
+    # /proc/PID/root cannot act as a path back to the original container root.
+    proc = runtime / "proc"
+    _directory(proc)
+    mount(
+        "proc",
+        proc,
+        "proc",
+        _MS_RDONLY | _MS_NOSUID | _MS_NODEV | _MS_NOEXEC,
+        "hidepid=2",
+    )
+    dev = runtime / "dev"
+    _directory(dev)
+    for name in ("null", "zero", "random", "urandom", "tty"):
+        bind(Path("/dev") / name, dev / name, readonly=False)
+    _directory(dev / "pts")
+    mount(
+        "devpts",
+        dev / "pts",
+        "devpts",
+        _MS_NOSUID | _MS_NOEXEC,
+        "newinstance,ptmxmode=0666,mode=0620",
+    )
+    (dev / "ptmx").symlink_to("pts/ptmx")
+    (dev / "shm").symlink_to(Path(scratch) / "shm")
+    (dev / "fd").symlink_to("/proc/self/fd")
+    for number, name in enumerate(("stdin", "stdout", "stderr")):
+        (dev / name).symlink_to(f"/proc/self/fd/{number}")
+
+    # Existing private paths fail with EACCES; other unpublished paths simply
+    # do not exist in this filesystem. Neither can expose original image bytes.
+    _directory(runtime / "opt" / "corral", 0)
+    for name in (
+        "root",
+        "home",
+        "corral-state",
+        "sys",
+        "srv",
+        "mnt",
+        "media",
+        "boot",
+        "run",
+    ):
+        _directory(jail / name, 0)
+    for name in ("passwd", "shadow", "group", "gshadow"):
+        (etc / name).touch(mode=0)
+
+    for name in ("usr", "bin", "sbin", "lib", "lib64", "opt", "etc", "proc", "dev"):
+        if (runtime / name).exists() or (runtime / name).is_symlink():
+            (jail / name).symlink_to(RUNTIME_ROOT / name)
+    (jail / "tmp").symlink_to(scratch)
+
+    # Only IPC/stdio may survive the chroot; an inherited directory or regular
+    # file descriptor would otherwise bypass the filesystem boundary.
+    for descriptor in list(Path("/proc/self/fd").iterdir()):
+        number = int(descriptor.name)
+        if number not in keep_fds:
+            with suppress(OSError):
+                os.close(number)
+    mount(None, jail, flags=_MS_REMOUNT | _MS_RDONLY | _MS_NOSUID | _MS_NODEV)
+    os.chroot(jail)
+    os.chdir(workspace)
+    return scratch

--- a/src/corral/runtime/agent_worker.py
+++ b/src/corral/runtime/agent_worker.py
@@ -1,0 +1,345 @@
+"""A narrow session broker for unprivileged native and SDK agent workers."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import secrets
+import socket
+import struct
+import threading
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import anyio
+from pydantic import TypeAdapter
+
+from corral.agents.schema import AgentOutcome
+from corral.agents.session import AgentSession, AgentSessionCapabilities, SubagentTrace
+from corral.core.action import Action
+from corral.core.actors import ActorRef
+from corral.core.tool import ToolConnection, ToolResponse
+from corral.runtime import permissions
+
+_MAX_MESSAGE = 64 * 1024 * 1024
+_METHODS = frozenset(
+    {
+        "execute",
+        "execute_many",
+        "record_message",
+        "record_messages",
+        "get_agent_state",
+        "set_agent_state",
+        "run_delegate",
+        "spawn_subagent",
+        "list_subagents",
+        "wait_for_subagent",
+        "inspect_subagent",
+        "import_subagent_context",
+        "fork_branch",
+        "promote_artifacts",
+        "shutdown_jobs",
+    }
+)
+_RETURNS = {
+    "execute": ToolResponse,
+    "execute_many": tuple[ToolResponse, ...],
+    "run_delegate": AgentOutcome,
+    "wait_for_subagent": AgentOutcome,
+    "inspect_subagent": SubagentTrace,
+}
+_ARGUMENTS = {
+    "execute": ("action",),
+    "execute_many": ("actions",),
+    "record_message": ("raw",),
+    "record_messages": ("raw_messages",),
+    "set_agent_state": ("namespace", "value"),
+    "run_delegate": ("agent",),
+    "spawn_subagent": ("agent",),
+    "wait_for_subagent": ("child_run_id",),
+    "inspect_subagent": ("child_run_id",),
+    "import_subagent_context": ("child_run_id",),
+}
+
+
+def _json(value: Any) -> Any:
+    return TypeAdapter(type(value)).dump_python(value, mode="json")
+
+
+def _snapshot(session: AgentSession) -> dict[str, Any]:
+    fields = (
+        "execution_id",
+        "execution_workspace",
+        "workspace",
+        "branch_id",
+        "actor",
+        "messages",
+        "examples",
+        "iteration_limit",
+        "prompt",
+        "task_id",
+        "tools",
+        "tool_connection",
+        "model_name",
+        "previous_messages",
+        "previous_commit_hash",
+        "surrender_allowed",
+        "submission",
+        "submission_status",
+        "capabilities",
+        "_require_submission",
+    )
+    snapshot = {name: _json(getattr(session, name)) for name in fields}
+    # Evaluation records can contain private scoring inputs and diagnostics.
+    # Reflexion needs only the public score and attempt identifier.
+    evaluation = session.previous_evaluation
+    snapshot["previous_evaluation"] = (
+        None
+        if evaluation is None
+        else {
+            key: value
+            for key, value in evaluation.items()
+            if (key == "score" and isinstance(value, int | float))
+            or (key == "trial_id" and isinstance(value, str))
+        }
+    )
+    return snapshot
+
+
+@dataclass
+class _DelegatedAgent:
+    """Opaque worker data; the trusted broker NEVER unpickles this payload."""
+
+    blob: str
+    tool_transport: str
+    session_capabilities: dict[str, bool]
+
+    async def run_session(self, session: AgentSession) -> AgentOutcome:
+        return await run_agent(self, session)
+
+
+class RemoteSession:
+    """The public session API, with all durable operations brokered as JSON."""
+
+    def __init__(
+        self, host: str, port: int, token: str, handle: str, snapshot: dict[str, Any]
+    ):
+        self._endpoint = (host, port)
+        self._token = token
+        self._handle = handle
+        self._update(snapshot)
+        self._initial_message_count = len(self.messages)
+        self.environment = SimpleNamespace(
+            shutdown_jobs=lambda: self._sync_call("shutdown_jobs", {})
+        )
+
+    def _update(self, snapshot: dict[str, Any]) -> None:
+        models = {
+            "actor": ActorRef,
+            "tool_connection": ToolConnection,
+            "capabilities": AgentSessionCapabilities,
+        }
+        for name, value in snapshot.items():
+            decoded = (
+                TypeAdapter(models[name]).validate_python(value)
+                if name in models and value is not None
+                else value
+            )
+            setattr(self, name, decoded)
+
+    def __getattr__(self, name: str) -> Any:
+        if name not in _METHODS:
+            raise AttributeError(name)
+
+        async def call(*args: Any, **kwargs: Any) -> Any:
+            names = _ARGUMENTS.get(name, ())
+            if len(args) > len(names):
+                raise TypeError(f"too many positional arguments to {name}")
+            arguments = {**dict(zip(names[: len(args)], args, strict=True)), **kwargs}
+            if "agent" in arguments:
+                agent = arguments["agent"]
+                arguments["agent"] = {
+                    "blob": base64.b64encode(permissions.serialize(agent)).decode(),
+                    "tool_transport": getattr(agent, "tool_transport", "python"),
+                    "session_capabilities": AgentSessionCapabilities.from_value(
+                        getattr(agent, "session_capabilities", None)
+                    ).to_metadata(),
+                }
+                if name == "spawn_subagent":
+                    arguments.setdefault("actor_id", type(agent).__name__)
+            arguments = {key: _json(value) for key, value in arguments.items()}
+            return await anyio.to_thread.run_sync(
+                lambda: self._sync_call(name, arguments)
+            )
+
+        return call
+
+    @staticmethod
+    def _read(stream: socket.socket, count: int) -> bytes:
+        chunks = bytearray()
+        while len(chunks) < count:
+            data = stream.recv(count - len(chunks))
+            if not data:
+                raise RuntimeError("session broker disconnected")
+            chunks.extend(data)
+        return bytes(chunks)
+
+    def _sync_call(self, method: str, arguments: dict[str, Any]) -> Any:
+        request = json.dumps(
+            {
+                "token": self._token,
+                "handle": self._handle,
+                "method": method,
+                "arguments": arguments,
+            }
+        ).encode()
+        if len(request) > _MAX_MESSAGE:
+            raise ValueError("session request is too large")
+        with socket.create_connection(self._endpoint) as stream:
+            stream.sendall(struct.pack("!I", len(request)) + request)
+            length = struct.unpack("!I", self._read(stream, 4))[0]
+            if length > _MAX_MESSAGE:
+                raise RuntimeError("session response is too large")
+            response = json.loads(self._read(stream, length))
+        if not response["ok"]:
+            raise RuntimeError(response["error"])
+        self._update(response["snapshot"])
+        value = response["result"]
+        if method == "fork_branch":
+            return RemoteSession(
+                *self._endpoint, self._token, value["handle"], value["snapshot"]
+            )
+        if method in _RETURNS:
+            return TypeAdapter(_RETURNS[method]).validate_python(value)
+        return value
+
+    def get_agent_state(self, namespace: str, *, previous: bool = False) -> Any:
+        """Read only this agent's bookkeeping, never an execution projection."""
+        return self._sync_call(
+            "get_agent_state", {"namespace": namespace, "previous": previous}
+        )
+
+    run_hooks = AgentSession.run_hooks
+
+    def final_messages(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self.messages[self._initial_message_count :])
+
+
+async def run_agent(agent: Any, session: AgentSession) -> AgentOutcome:
+    """Keep implementations unchanged while moving their process off root."""
+    workspace = session.workspace
+    if not workspace:
+        raise RuntimeError("Docker agents require an assigned workspace")
+    snapshot = _snapshot(session)
+    token = secrets.token_hex(32)
+    handle = secrets.token_hex(16)
+    sessions = {handle: session}
+    tasks: set[asyncio.Task[Any]] = set()
+
+    async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        task = asyncio.current_task()
+        tasks.add(task)
+        try:
+            length = struct.unpack("!I", await reader.readexactly(4))[0]
+            if length > _MAX_MESSAGE:
+                raise ValueError("session request is too large")
+            request = json.loads(await reader.readexactly(length))
+            if not secrets.compare_digest(request["token"], token):
+                raise PermissionError("invalid session capability")
+            selected = sessions[request["handle"]]
+            method = request["method"]
+            if method not in _METHODS:
+                raise PermissionError("session operation is not permitted")
+            arguments = request["arguments"]
+            if method == "fork_branch":
+                arguments.setdefault("workspace_parent", workspace)
+                if arguments["workspace_parent"] != workspace:
+                    raise PermissionError(
+                        "node workspaces must belong to the calling agent"
+                    )
+            if method == "execute":
+                arguments["action"] = TypeAdapter(Action).validate_python(
+                    arguments["action"]
+                )
+            elif method == "execute_many":
+                arguments["actions"] = TypeAdapter(tuple[Action, ...]).validate_python(
+                    arguments["actions"]
+                )
+            elif method in {"run_delegate", "spawn_subagent"}:
+                supplied = arguments["agent"]
+                arguments["agent"] = _DelegatedAgent(
+                    blob=supplied["blob"],
+                    tool_transport=supplied["tool_transport"],
+                    session_capabilities=AgentSessionCapabilities.from_value(
+                        supplied["session_capabilities"]
+                    ).to_metadata(),
+                )
+            if method == "get_agent_state":
+                result = selected.get_agent_state(**arguments)
+            elif method == "shutdown_jobs":
+                await anyio.to_thread.run_sync(selected.environment.shutdown_jobs)
+                result = None
+            else:
+                result = await getattr(selected, method)(**arguments)
+            if method == "fork_branch":
+                branch_handle = secrets.token_hex(16)
+                sessions[branch_handle] = result
+                result = {"handle": branch_handle, "snapshot": _snapshot(result)}
+            elif method == "inspect_subagent":
+                # Raw commits contain hidden environment updates and artifact
+                # references. Only the child's public conversation may cross.
+                result = _json(result)
+                result["context"]["task"] = {}
+                result["commits"] = []
+            elif method == "import_subagent_context":
+                result = result.hash
+            response = {
+                "ok": True,
+                "result": _json(result),
+                "snapshot": _snapshot(selected),
+            }
+        except Exception as exc:
+            response = {"ok": False, "error": str(exc)}
+        try:
+            data = json.dumps(response).encode()
+            if len(data) > _MAX_MESSAGE:
+                data = b'{"ok":false,"error":"session response is too large"}'
+            writer.write(struct.pack("!I", len(data)) + data)
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            tasks.discard(task)
+
+    server = await asyncio.start_server(serve, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    cancelled = threading.Event()
+    worker = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            lambda: permissions.run_worker(
+                "agent",
+                (agent, ("127.0.0.1", port, token, handle, snapshot)),
+                workspace,
+                cancel=cancelled,
+            ),
+        )
+    )
+    try:
+        result = await asyncio.shield(worker)
+        return TypeAdapter(AgentOutcome).validate_python(result)
+    finally:
+        cancelled.set()
+        # Complete identity cleanup before the controller releases this session
+        # or returns checkpoint ownership to the host user.
+        with anyio.CancelScope(shield=True):
+            await asyncio.gather(worker, return_exceptions=True)
+        server.close()
+        await server.wait_closed()
+        for task in tuple(tasks):
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        for selected in sessions.values():
+            if selected is not session:
+                await anyio.to_thread.run_sync(selected.environment.shutdown_jobs)

--- a/src/corral/runtime/permissions.py
+++ b/src/corral/runtime/permissions.py
@@ -1,0 +1,650 @@
+"""Unix identities for model-controlled execution in Docker trials.
+
+The root controller owns source and checkpoints. Workers permanently drop all
+three user/group IDs before invoking agent or tool code. Only JSON is accepted
+back from workers; untrusted pickle data must never be loaded by the controller.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import io
+import itertools
+import json
+import os
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from contextlib import contextmanager, suppress
+from functools import cache
+from pathlib import Path
+from typing import Any, ClassVar
+from uuid import uuid4
+
+import cloudpickle
+
+DENIED = "Permission denied: access outside the trial workspace is not permitted"
+POLICY_VERSION = "workspace-root-v1"
+SCRATCH_PREFIX = ".corral-runtime-"
+NODE_WORKSPACE_DIR = ".corral-nodes"
+_enabled = False
+_identities = itertools.count(20000)
+_groups: dict[Path, int] = {}
+_node_parents: dict[Path, Path] = {}
+_lock = threading.Lock()
+_root: Path | None = None
+
+
+def _restore_prompt(attributes: dict[str, Any]):
+    from promptstore import Prompt  # - load only during serialization
+
+    return Prompt(**attributes)
+
+
+def _reduce_prompt(prompt: Any):
+    return _restore_prompt, (
+        {
+            key: value
+            for key, value in vars(prompt).items()
+            if key not in {"_template", "variables"}
+        },
+    )
+
+
+def _restore_hooks(callbacks: Any):
+    from corral.agents.hooks import (  # - avoid session import cycle
+        AgentHooks,
+    )
+
+    hooks = AgentHooks()
+    hooks._hooks = callbacks
+    return hooks
+
+
+def _reduce_hooks(hooks: Any):
+    with hooks._lock:
+        return _restore_hooks, (dict(hooks._hooks),)
+
+
+@cache
+def private_controller_types() -> tuple[type, ...]:
+    """Preload serialization guards before a worker loses source access."""
+    from corral.agents.session import AgentSession
+    from corral.core.commit import Commit
+    from corral.core.environment import Environment
+    from corral.core.state import ExecutionState
+    from corral.core.task import TaskDefinition
+
+    return AgentSession, ExecutionState, Environment, TaskDefinition, Commit
+
+
+def serialize(value: Any) -> bytes:
+    """Transfer public configuration, refusing captured controller objects."""
+    from promptstore import Prompt  # - load only during serialization
+
+    from corral.agents.hooks import AgentHooks
+
+    private_types = private_controller_types()
+
+    class WorkerPickler(cloudpickle.CloudPickler):
+        def persistent_id(self, obj: Any) -> None:
+            if isinstance(obj, private_types):
+                raise ValueError(
+                    f"private controller object cannot enter a worker: {type(obj).__name__}"
+                )
+
+        dispatch_table: ClassVar[dict] = {
+            **cloudpickle.CloudPickler.dispatch_table,
+            Prompt: _reduce_prompt,
+            AgentHooks: _reduce_hooks,
+        }
+
+    stream = io.BytesIO()
+    pickler = WorkerPickler(stream)
+    pickler.dump(value)
+    return stream.getvalue()
+
+
+def _open_directory(path: str | Path | int) -> int:
+    """Pin a directory without following links in any path component."""
+    if isinstance(path, int):
+        return os.dup(path)
+    absolute = Path(os.path.abspath(path))  # noqa: PTH100 - resolve would follow untrusted links
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    descriptor = os.open(absolute.anchor, flags)
+    try:
+        for component in absolute.parts[1:]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _entries(directory: int, prefix: str = ""):
+    """Open entries relative to pinned directory FDs; never follow a link."""
+    for name in sorted(os.listdir(directory)):
+        # SDK homes can contain sockets and executable aliases. They are private
+        # scratch within the workspace, not task artifacts or shared task files.
+        if not prefix and (
+            name.startswith(SCRATCH_PREFIX) or name == NODE_WORKSPACE_DIR
+        ):
+            continue
+        descriptor = os.open(
+            name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=directory
+        )
+        try:
+            status = os.fstat(descriptor)
+            relative = prefix + name
+            if not (stat.S_ISREG(status.st_mode) or stat.S_ISDIR(status.st_mode)):
+                raise ValueError(
+                    f"workspace can contain regular files only: {relative}"
+                )
+            yield relative, descriptor, status
+            if stat.S_ISDIR(status.st_mode):
+                yield from _entries(descriptor, relative + "/")
+        finally:
+            os.close(descriptor)
+
+
+def copy_workspace(
+    source: str | Path | int, destination: str | Path | int
+) -> list[str]:
+    """Copy authorized workspace data without a privileged symlink race."""
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    source_fd = _open_directory(source)
+    try:
+        destination_fd = _open_directory(destination)
+        try:
+            destination_gid = os.fstat(destination_fd).st_gid
+            copied = []
+            for relative, descriptor, status in _entries(source_fd):
+                parent = os.dup(destination_fd)
+                try:
+                    parts = relative.split("/")
+                    for component in parts[:-1]:
+                        next_parent = os.open(component, directory_flags, dir_fd=parent)
+                        os.close(parent)
+                        parent = next_parent
+                    if stat.S_ISDIR(status.st_mode):
+                        with suppress(FileExistsError):
+                            os.mkdir(parts[-1], mode=0o770, dir_fd=parent)  # noqa: PTH102 - Path.mkdir does not support dir_fd
+                        existing = os.open(parts[-1], directory_flags, dir_fd=parent)
+                        try:
+                            if enabled():
+                                os.fchown(existing, 0, destination_gid)
+                            os.fchmod(existing, (status.st_mode & 0o777) | 0o2770)
+                        finally:
+                            os.close(existing)
+                    else:
+                        target = os.open(
+                            parts[-1],
+                            os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW | os.O_NONBLOCK,
+                            0o660,
+                            dir_fd=parent,
+                        )
+                        try:
+                            if not stat.S_ISREG(os.fstat(target).st_mode):
+                                raise ValueError(
+                                    "workspace destination must be a regular file"
+                                )
+                            # The controller's private umask must not hide newly
+                            # promoted outputs from the owning workspace group.
+                            # It lacks FSETID, so directory setgid inheritance
+                            # cannot be relied on for controller-created files.
+                            if enabled():
+                                os.fchown(target, 0, destination_gid)
+                            os.fchmod(target, (status.st_mode & 0o777) | 0o660)
+                            os.ftruncate(target, 0)
+                            while chunk := os.read(descriptor, 1024 * 1024):
+                                view = memoryview(chunk)
+                                while view:
+                                    view = view[os.write(target, view) :]
+                        finally:
+                            os.close(target)
+                        copied.append(relative)
+                finally:
+                    os.close(parent)
+            return copied
+        finally:
+            os.close(destination_fd)
+    finally:
+        os.close(source_fd)
+
+
+def create_node_workspace(parent: str, source: str) -> str:
+    """Allocate a sibling node directory and copy only its parent's task files."""
+    parent_path = Path(os.path.abspath(parent))  # noqa: PTH100 - do not follow links
+    source_path = Path(os.path.abspath(source))  # noqa: PTH100 - do not follow links
+    if not source_path.is_relative_to(parent_path):
+        raise ValueError("node source must belong to its parent workspace")
+    if enabled():
+        # The main worker already has this group. Children use the same group
+        # so it can inspect their files; their private mounts enforce isolation.
+        workspace_identity(parent)
+    parent_fd = _open_directory(parent)
+    try:
+        with suppress(FileExistsError):
+            os.mkdir(NODE_WORKSPACE_DIR, mode=0o2770, dir_fd=parent_fd)  # noqa: PTH102 - Path.mkdir does not support dir_fd
+        nodes_fd = os.open(
+            NODE_WORKSPACE_DIR,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            dir_fd=parent_fd,
+        )
+        try:
+            if enabled():
+                os.fchown(nodes_fd, 0, _groups[parent_path])
+                os.fchmod(nodes_fd, 0o2770)
+            name = uuid4().hex
+            os.mkdir(name, mode=0o2770, dir_fd=nodes_fd)  # noqa: PTH102 - Path.mkdir does not support dir_fd
+            node_fd = os.open(
+                name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=nodes_fd
+            )
+            try:
+                copy_workspace(source, node_fd)
+            finally:
+                os.close(node_fd)
+        finally:
+            os.close(nodes_fd)
+    finally:
+        os.close(parent_fd)
+    node = parent_path / NODE_WORKSPACE_DIR / name
+    if enabled():
+        with _lock:
+            _node_parents[node] = parent_path
+        workspace_identity(node)
+    return str(node)
+
+
+@contextmanager
+def snapshot_source(source: str | Path):
+    """Give artifact storage an immutable-to-agents, safely opened copy."""
+    if _root is None:
+        raise RuntimeError("Docker permission enforcement has not been configured")
+    with tempfile.TemporaryDirectory(dir=_root) as directory:
+        copy_workspace(source, directory)
+        yield Path(directory)
+
+
+def prepare_image() -> None:
+    """Protect image data while retaining the public OS/language runtime."""
+    for name in (
+        "/opt/corral",
+        "/root",
+        "/home",
+        "/var",
+        "/run",
+        "/srv",
+        "/mnt",
+        "/media",
+        "/boot",
+    ):
+        directory = Path(name)
+        if directory.is_dir() and not directory.is_symlink():
+            os.chown(directory, 0, 0)
+            directory.chmod(0o700)
+    # DNS, certificates, and the dynamic loader need these particular resources;
+    # other image configuration is private, including passwd and package config.
+    public = (
+        "ssl/certs",
+        "pki/tls/certs",
+        "ca-certificates",
+        "alternatives",
+        "resolv.conf",
+        "hosts",
+        "nsswitch.conf",
+        "localtime",
+        "ld.so.cache",
+    )
+    generated = {Path("/etc/hosts"), Path("/etc/resolv.conf"), Path("/etc/hostname")}
+    for directory, directories, files in os.walk("/etc", followlinks=False):
+        for name in (*directories, *files):
+            entry = Path(directory) / name
+            if not entry.is_symlink() and entry not in generated:
+                entry.chmod(entry.stat().st_mode & 0o700)
+    Path("/etc").chmod(0o711)
+    for name in public:
+        entry = Path("/etc") / name
+        if not entry.exists():
+            continue
+        for parent in entry.parents:
+            if parent == Path("/etc"):
+                break
+            parent.chmod(0o711)
+        if not entry.is_symlink() and entry not in generated:
+            entry.chmod(0o755 if entry.is_dir() else 0o644)
+        if entry.is_dir():
+            for child in entry.rglob("*"):
+                if not child.is_symlink():
+                    child.chmod(0o755 if child.is_dir() else 0o644)
+
+
+def enabled() -> bool:
+    return _enabled
+
+
+def configure(checkpoints: Path) -> None:
+    """Enable confinement in the trusted, container-only entry point."""
+    global _enabled, _root  # noqa: PLW0603 - one trusted policy per trial process
+    if sys.platform != "linux" or os.geteuid() != 0:
+        raise RuntimeError(
+            "Docker permission enforcement requires a root Linux controller"
+        )
+    source = Path(__file__).resolve().parents[3]
+    if source != Path("/opt/corral"):
+        raise RuntimeError("Docker source must be installed privately at /opt/corral")
+    for private in (source, checkpoints):
+        status = private.stat()
+        if status.st_uid != 0 or status.st_mode & 0o077:
+            raise RuntimeError(
+                f"Private Docker directory must be root-owned mode 0700: {private}"
+            )
+    if Path("/etc/passwd").stat().st_mode & 0o077:
+        raise RuntimeError(
+            "Docker image has not been prepared for Unix worker permissions"
+        )
+    # /tmp and shared memory otherwise provide writable paths outside workspace.
+    for private in (Path("/tmp"), Path("/dev/shm")):
+        os.chown(private, 0, 0)
+        private.chmod(0o700)
+    os.umask(0o077)
+    Path("/workspace").chmod(0o711)
+    _root = checkpoints / "workers"
+    _root.mkdir(mode=0o700, exist_ok=True)
+    _enabled = True
+
+
+def workspace_identity(
+    workspace: str | Path, *, descriptor: int | None = None
+) -> tuple[int, int]:
+    root = Path(os.path.abspath(workspace))  # noqa: PTH100 - do not follow links
+    if root == Path("/workspace") or not root.is_relative_to("/workspace"):
+        raise ValueError("workers require an assigned directory below /workspace")
+    if root.is_relative_to("/workspace/.corral-runtime-system"):
+        raise ValueError("the worker runtime path is reserved")
+    with _lock:
+        parent = _node_parents.get(root)
+        if root not in _groups:
+            if parent is not None:
+                _groups[root] = _groups[parent]
+            elif any(
+                root.is_relative_to(existing) or existing.is_relative_to(root)
+                for existing in _groups
+            ):
+                raise ValueError("nested workspaces must be assigned by the controller")
+            else:
+                _groups[root] = next(_identities)
+        gid = _groups[root]
+        uid = next(_identities)
+    # Parent directories are traversable, but only the assigned group can enter
+    # a materialization. The controller needs DAC_OVERRIDE for hostile file modes.
+    descriptor = _open_directory(root if descriptor is None else descriptor)
+    try:
+        _allow_workspace_group(descriptor, gid)
+    finally:
+        os.close(descriptor)
+    return uid, gid
+
+
+def _allow_workspace_group(descriptor: int, gid: int) -> None:
+    os.fchown(descriptor, 0, gid)
+    os.fchmod(descriptor, 0o2770)
+    for _name, entry, status in _entries(descriptor):
+        os.fchown(entry, 0, gid)
+        os.fchmod(
+            entry,
+            (status.st_mode & 0o777)
+            | (0o2770 if stat.S_ISDIR(status.st_mode) else 0o660),
+        )
+
+
+def drop_privileges(
+    uid: int, gid: int, workspace: str, *, scratch: str | None = None
+) -> None:
+    """Irreversibly enter the worker identity before running supplied code."""
+    if os.geteuid() != 0 or uid <= 0 or gid <= 0:
+        raise RuntimeError("restricted workers must start at the trusted bootstrap")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(38, 1, 0, 0, 0):  # PR_SET_NO_NEW_PRIVS
+        raise OSError(ctypes.get_errno(), "cannot set no_new_privs")
+    os.setgroups([])
+    os.setresgid(gid, gid, gid)
+    os.setresuid(uid, uid, uid)
+    if os.getresuid() != (uid, uid, uid) or os.getresgid() != (gid, gid, gid):
+        raise RuntimeError("failed to drop worker privileges")
+    status = Path("/proc/self/status").read_text()
+    for field in ("CapInh", "CapPrm", "CapEff", "CapAmb"):
+        if int(status.split(field + ":", 1)[1].splitlines()[0].strip(), 16):
+            raise RuntimeError(f"worker retained Linux capabilities: {field}")
+    os.umask(0o007)
+    os.chdir(workspace)
+    if scratch is None:
+        scratch = tempfile.mkdtemp(prefix=SCRATCH_PREFIX, dir=workspace)
+    os.environ.update(HOME=scratch, TMPDIR=scratch, XDG_CACHE_HOME=scratch + "/.cache")
+    tempfile.tempdir = scratch
+
+
+def _kill_identity(uid: int) -> None:
+    """Stop descendants, including detached processes and racing forks."""
+    deadline = time.monotonic() + 5
+    while True:
+        found = False
+        for status in Path("/proc").glob("[0-9]*/status"):
+            try:
+                text = status.read_text()
+                fields = text.split("Uid:", 1)[1].splitlines()[0].split()
+                if (
+                    int(fields[0]) != uid
+                    or text.split("State:", 1)[1].split()[0] == "Z"
+                ):
+                    continue
+                found = True
+                pid = int(status.parent.name)
+                os.kill(pid, signal.SIGSTOP)
+                os.kill(pid, signal.SIGKILL)
+            except (FileNotFoundError, ProcessLookupError):
+                continue
+        if not found:
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError("restricted worker descendants could not be stopped")
+        time.sleep(0.01)
+
+
+def run_worker(
+    kind: str, payload: Any, workspace: str, *, cancel: threading.Event | None = None
+) -> Any:
+    """Run one trusted bootstrap, then accept an unprivileged JSON result."""
+    if not enabled() or _root is None:
+        raise RuntimeError("restricted workers require Docker permission enforcement")
+    descriptor = _open_directory(workspace)
+    try:
+        return _run_worker(kind, payload, workspace, descriptor, cancel=cancel)
+    finally:
+        try:
+            root = Path(workspace)
+            if root in _node_parents:
+                # A tool may create mode-0600 outputs. Once it and its children
+                # have stopped, restore the main agent's access to node files.
+                _allow_workspace_group(descriptor, _groups[root])
+        finally:
+            os.close(descriptor)
+
+
+def _run_worker(
+    kind: str,
+    payload: Any,
+    workspace: str,
+    workspace_fd: int,
+    *,
+    cancel: threading.Event | None,
+) -> Any:
+    uid, gid = workspace_identity(workspace, descriptor=workspace_fd)
+    with tempfile.TemporaryDirectory(dir=_root) as directory:
+        request = Path(directory) / "input.pkl"
+        request.write_bytes(
+            serialize((kind, payload, uid, gid, workspace, workspace_fd))
+        )
+        request.chmod(0o600)
+        reader, writer = os.pipe()
+        output: list[bytes] = []
+
+        def read_result() -> None:
+            with os.fdopen(reader, "rb") as stream:
+                output.append(stream.read(64 * 1024 * 1024 + 1))
+
+        thread = threading.Thread(target=read_result, daemon=True)
+        thread.start()
+        try:
+            with tempfile.TemporaryFile(dir=_root) as log:
+                process = subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-m",
+                        "corral.runtime._permission_worker",
+                        str(request),
+                        str(writer),
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    # A write-only pipe is the only log handle inherited by the
+                    # worker; never expose the controller's private log file FD.
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    # Environment factories may add private task import roots.
+                    # The fresh trusted bootstrap needs the same module paths.
+                    env={**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)},
+                    pass_fds=(writer, workspace_fd),
+                    start_new_session=True,
+                )
+
+                def read_log() -> None:
+                    with process.stdout as stream:
+                        while chunk := stream.read(64 * 1024):
+                            log.write(chunk)
+
+                log_thread = threading.Thread(target=read_log, daemon=True)
+                log_thread.start()
+                os.close(writer)
+                writer = -1
+                try:
+                    while True:
+                        try:
+                            process.wait(timeout=0.1)
+                            break
+                        except subprocess.TimeoutExpired:
+                            if cancel is not None and cancel.is_set():
+                                _kill_identity(uid)
+                                process.kill()
+                                process.wait()
+                                raise RuntimeError(
+                                    "restricted worker cancelled"
+                                ) from None
+                finally:
+                    _kill_identity(uid)
+                    thread.join(timeout=5)
+                    log_thread.join(timeout=5)
+                if log_thread.is_alive():
+                    raise RuntimeError("restricted worker log stream did not close")
+                if thread.is_alive() or not output or len(output[0]) > 64 * 1024 * 1024:
+                    raise RuntimeError("restricted worker returned an invalid response")
+                if process.returncode or not output[0]:
+                    log.seek(0, os.SEEK_END)
+                    log.seek(max(0, log.tell() - 16000))
+                    raise RuntimeError(
+                        "restricted worker failed: "
+                        + log.read().decode(errors="replace")
+                    )
+                response = json.loads(output[0])
+                if not response["ok"]:
+                    raise RuntimeError(response["error"])
+                return response["result"]
+        finally:
+            if writer >= 0:
+                os.close(writer)
+
+
+def execute_tool(
+    environment: Any, state: Any, tool: Any, arguments: dict[str, Any]
+) -> Any:
+    """Keep private task logic here; give code workers only public arguments."""
+    from corral.backend.background_tools import (  # - avoid tool import cycle
+        _CallableTool,
+    )
+
+    # Job controls and explicitly trusted scientific functions never evaluate
+    # model-controlled code. They alone may receive the execution projection.
+    if isinstance(tool, _CallableTool) or getattr(tool, "trusted", False):
+        return environment.execute_tool(state, tool, arguments)
+    return _run_public_tool(tool, arguments, environment.workspace_path)
+
+
+def visible_argument_error(tool: Any, arguments: dict[str, Any]) -> str | None:
+    """Validate the public schema before preprocessing or injecting private data."""
+    from jsonschema import Draft202012Validator
+
+    schema = {
+        **tool.params_json_schema,
+        "required": [argument.name for argument in tool.arguments if argument.required],
+        "additionalProperties": False,
+    }
+    error = next(Draft202012Validator(schema).iter_errors(arguments), None)
+    return None if error is None else f"invalid visible tool arguments: {error.message}"
+
+
+def _run_public_tool(
+    tool: Any,
+    arguments: dict[str, Any],
+    workspace: str,
+    *,
+    cancel: threading.Event | None = None,
+) -> Any:
+    workspace_args = set(getattr(tool, "workspace_args", ()))
+    if set(tool.hidden_args) - workspace_args:
+        raise PermissionError(
+            "restricted tools cannot receive hidden arguments; "
+            "private inputs require explicitly trusted task logic"
+        )
+    public = {
+        name: value for name, value in arguments.items() if name not in tool.hidden_args
+    }
+    if error := visible_argument_error(tool, public):
+        raise ValueError(error)
+    public.update(dict.fromkeys(workspace_args, workspace))
+    operation = getattr(tool, "worker_operation", None)
+    if operation == "terminal":
+        result = run_worker("terminal", public, workspace, cancel=cancel)
+    else:
+        result = run_worker("tool", (tool, public), workspace, cancel=cancel)
+    return result["content"]
+
+
+def execute_job(
+    tool: Any,
+    arguments: dict[str, Any],
+    workspace: str,
+    *,
+    cancel: threading.Event | None = None,
+) -> Any:
+    """Background jobs obey the same trust classification as foreground tools."""
+    if getattr(tool, "trusted", False):
+        from corral.core.transition import ToolExecutionResult
+
+        result = tool.execute(**arguments)
+        if isinstance(result, ToolExecutionResult):
+            if result.environment is not None:
+                raise ValueError("stateful task tools must execute in the foreground")
+            return result.content
+        return result
+    return _run_public_tool(tool, arguments, workspace, cancel=cancel)
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != ["--prepare-image"]:
+        raise SystemExit("expected --prepare-image")
+    prepare_image()

--- a/src/corral/workspace/filesystem.py
+++ b/src/corral/workspace/filesystem.py
@@ -89,8 +89,13 @@ class WorkspaceFilesystem:
     def _resolve(self, path: str, *, allow_root: bool = False) -> Path:
         if allow_root and path in {"", "."}:
             return self.root
-        normalized = normalize_workspace_path(path)
-        return confine_workspace_path(self.root, normalized, allow_root=allow_root)
+        try:
+            normalized = normalize_workspace_path(path)
+            return confine_workspace_path(self.root, normalized, allow_root=allow_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"Permission denied: operation is not permitted: {exc}"
+            ) from exc
 
     def _logical_path(self, path: Path) -> str:
         resolved = path.resolve(strict=False)
@@ -392,36 +397,21 @@ def build_terminal_tool(filesystem: WorkspaceFilesystem) -> Tool:
         if not 1 <= max_output_chars <= _TERMINAL_MAX_OUTPUT_CHARS:
             raise ValueError("max_output_chars must be between 1 and 100000")
 
-        terminal_uid = int(os.environ.get("CORRAL_TERMINAL_UID", str(os.geteuid())))
-        terminal_gid = int(os.environ.get("CORRAL_TERMINAL_GID", str(os.getegid())))
-
-        identity_options: dict[str, Any] = {}
-        if os.geteuid() == 0 and terminal_uid != 0:
-            # The runtime owns the volume; the terminal user owns only this
-            # materialization and never the separately mounted checkpoint path.
-            for entry in (filesystem.root, *filesystem.root.rglob("*")):
-                if entry.is_symlink():
-                    raise ValueError("workspace cannot contain symbolic links")
-                entry.chown(terminal_uid, terminal_gid)
-            identity_options = {
-                "user": terminal_uid,
-                "group": terminal_gid,
-                "extra_groups": (),
-            }
-
+        # The shell inherits its caller's identity; Docker tool workers have
+        # already dropped privileges at the shared execution boundary.
         with tempfile.TemporaryFile() as output_stream:
             process = subprocess.Popen(
-                ["/bin/sh", "-lc", command],
+                ["/bin/sh", "-c", command],
                 cwd=filesystem.root,
                 env={
                     "HOME": str(filesystem.root),
+                    "TMPDIR": str(filesystem.root),
                     "LANG": "C.UTF-8",
-                    "PATH": "/usr/local/bin:/usr/bin:/bin",
+                    "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
                 },
                 stdout=output_stream,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
-                **identity_options,
             )
             timed_out = False
             try:
@@ -453,4 +443,7 @@ def build_terminal_tool(filesystem: WorkspaceFilesystem) -> Tool:
             indent=2,
         )
 
+    # The restricted bootstrap rebuilds this tool from the workspace path.
+    # No controller-side callable or environment is serialized for shell input.
+    terminal.worker_operation = "terminal"
     return terminal

--- a/tasks/corral_md/src/corral_md/modal_workspace.py
+++ b/tasks/corral_md/src/corral_md/modal_workspace.py
@@ -8,9 +8,14 @@ import shutil
 import tempfile
 import uuid
 from pathlib import Path, PurePosixPath
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import modal
+
+from corral.runtime.permissions import NODE_WORKSPACE_DIR, SCRATCH_PREFIX
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 _LOGGER = logging.getLogger(__name__)
 _DEFAULT_APP_NAME = "simagent"
@@ -30,13 +35,27 @@ def _modal_app_name() -> str:
     return f"{_DEFAULT_APP_NAME}{suffix if suffix.startswith('-') else f'-{suffix}'}"
 
 
+def _is_runtime_name(name: str) -> bool:
+    return name.startswith(SCRATCH_PREFIX) or name == NODE_WORKSPACE_DIR
+
+
+def _workspace_entries(workspace: Path, *, recursive: bool = False) -> Iterator[Path]:
+    """Visit task files without entering private worker or node directories."""
+    for entry in workspace.iterdir():
+        if _is_runtime_name(entry.name):
+            continue
+        yield entry
+        if recursive and entry.is_dir() and not entry.is_symlink():
+            yield from entry.rglob("*")
+
+
 def _validate_workspace(workspace: str | Path) -> Path:
     workspace_path = Path(workspace)
     if workspace_path.is_symlink() or not workspace_path.is_dir():
         raise ValueError(f"LAMMPS workspace must be a regular directory: {workspace}")
 
     root = workspace_path.resolve()
-    for entry in root.rglob("*"):
+    for entry in _workspace_entries(root, recursive=True):
         relative = entry.relative_to(root).as_posix()
         if entry.is_symlink():
             raise ValueError(f"LAMMPS workspace cannot contain symlinks: {relative}")
@@ -55,9 +74,14 @@ def _resolve_input(workspace: Path, input_file: str) -> tuple[Path, PurePosixPat
         raise ValueError(
             f"LAMMPS input must be inside the current workspace: {input_file}"
         )
+    relative = local_input.relative_to(workspace)
+    if relative.parts and _is_runtime_name(relative.parts[0]):
+        raise ValueError(
+            f"LAMMPS input cannot name a runtime workspace path: {input_file}"
+        )
     if local_input.is_symlink() or not local_input.is_file():
         raise FileNotFoundError(f"LAMMPS input file was not found: {input_file}")
-    return local_input, PurePosixPath(local_input.relative_to(workspace).as_posix())
+    return local_input, PurePosixPath(relative.as_posix())
 
 
 def _entry_kind(entry: Any) -> str:
@@ -83,7 +107,9 @@ def _entry_relative_path(entry: Any, remote_directory: PurePosixPath) -> Path:
         ) from exc
     if str(relative) in {"", "."}:
         return Path()
-    if any(part in {"", ".", ".."} for part in relative.parts):
+    if any(part in {"", ".", ".."} for part in relative.parts) or _is_runtime_name(
+        relative.parts[0]
+    ):
         raise RuntimeError(f"Modal returned an unsafe workspace path: {entry.path!r}")
     return Path(*relative.parts)
 
@@ -126,15 +152,23 @@ def _download_workspace(
 
 
 def _publish_workspace(staged_workspace: Path, workspace: Path) -> None:
-    backup = workspace.parent / f".{workspace.name}.corral-backup-{uuid.uuid4().hex}"
-    workspace.replace(backup)
+    # The workspace may be a bind mount with a non-writable parent. Preserve its
+    # inode, ownership and mode, and leave active worker scratch in place.
+    backup = staged_workspace.parent / "backup"
+    backup.mkdir()
+    published: list[Path] = []
     try:
-        staged_workspace.replace(workspace)
+        for entry in list(_workspace_entries(workspace)):
+            entry.replace(backup / entry.name)
+        for entry in list(staged_workspace.iterdir()):
+            target = entry.replace(workspace / entry.name)
+            published.append(target)
     except Exception:
-        backup.replace(workspace)
+        for entry in reversed(published):
+            entry.replace(staged_workspace / entry.name)
+        for entry in list(backup.iterdir()):
+            entry.replace(workspace / entry.name)
         raise
-    else:
-        shutil.rmtree(backup)
 
 
 def run_lammps_in_modal(
@@ -145,12 +179,12 @@ def run_lammps_in_modal(
     remote_function: Any | None = None,
     job_id: str | None = None,
 ) -> tuple[Path, int]:
-    """Run LAMMPS on Modal and replace the local workspace with its outputs.
+    """Run LAMMPS on Modal and synchronize its outputs into the local workspace.
 
-    The complete local workspace is uploaded to a unique directory in the
+    Local task files are uploaded to a unique directory in the
     `simulations` Volume. The deployed `run_lammps` function executes there,
     commits its writes, and this function downloads the complete directory into
-    a staging area before atomically publishing it at the original local path.
+    staging inside the workspace before replacing its task files in place.
     """
 
     local_workspace = _validate_workspace(workspace)
@@ -175,7 +209,12 @@ def run_lammps_in_modal(
         remote_function = modal.Function.from_name(_modal_app_name(), "run_lammps")
 
     with volume.batch_upload(force=True) as upload:
-        upload.put_directory(str(local_workspace), str(remote_volume_directory))
+        for entry in _workspace_entries(local_workspace):
+            remote_path = str(remote_volume_directory / entry.name)
+            if entry.is_dir():
+                upload.put_directory(str(entry), remote_path)
+            else:
+                upload.put_file(str(entry), remote_path)
 
     remote_error: Exception | None = None
     try:
@@ -189,9 +228,7 @@ def run_lammps_in_modal(
         remote_error = exc
 
     temporary_root = Path(
-        tempfile.mkdtemp(
-            prefix=f".{local_workspace.name}.modal-", dir=local_workspace.parent
-        )
+        tempfile.mkdtemp(prefix=f"{SCRATCH_PREFIX}modal-", dir=local_workspace)
     )
     staged_workspace = temporary_root / "workspace"
     staged_workspace.mkdir()

--- a/tasks/corral_md/tests/test_modal_workspace.py
+++ b/tasks/corral_md/tests/test_modal_workspace.py
@@ -12,11 +12,12 @@ from corral_md.env import (
     _md_file_tools,
     _md_task_prompt,
 )
-from corral_md.modal_workspace import run_lammps_in_modal
+from corral_md.modal_workspace import _publish_workspace, run_lammps_in_modal
 from corral_md.score import check_log, check_numerical
 
 from corral.core.environment import Toolset
 from corral.core.task import TaskDefinition
+from corral.runtime.permissions import NODE_WORKSPACE_DIR, SCRATCH_PREFIX
 
 
 class _EntryType(Enum):
@@ -39,6 +40,9 @@ class _Upload:
 
     def __exit__(self, *_args) -> None:
         return None
+
+    def put_file(self, local_path: str, remote_path: str) -> None:
+        self.volume.files[remote_path] = Path(local_path).read_bytes()
 
     def put_directory(self, local_path: str, remote_path: str) -> None:
         root = Path(local_path)
@@ -89,6 +93,7 @@ class _RemoteFunction:
         self.volume = volume
         self.error = error
         self.calls: list[tuple[str, str, str, str]] = []
+        self.uploaded_files: dict[str, bytes] = {}
 
     def remote(
         self,
@@ -98,6 +103,7 @@ class _RemoteFunction:
         remote_workspace: str,
     ) -> None:
         self.calls.append((input_file, log_file, local_workspace, remote_workspace))
+        self.uploaded_files = dict(self.volume.files)
         volume_workspace = remote_workspace.removeprefix("/results")
         self.volume.files[f"{volume_workspace}/{log_file}"] = b"LAMMPS log\n"
         self.volume.files[f"{volume_workspace}/trajectory.dump"] = b"atoms\n"
@@ -105,22 +111,41 @@ class _RemoteFunction:
             raise self.error
 
 
-def test_modal_lammps_round_trip_replaces_local_workspace(tmp_path: Path) -> None:
+def test_modal_lammps_round_trip_preserves_workspace_boundary(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "run.in").write_text("read_data structure.data\n")
     (workspace / "structure.data").write_text("atoms\n")
+    workspace.chmod(0o2770)
+    original_stat = workspace.stat()
 
     volume = _Volume()
     function = _RemoteFunction(volume)
-    log_path, downloaded = run_lammps_in_modal(
-        workspace,
-        "run.in",
-        volume=volume,
-        remote_function=function,
-        job_id="job-1",
-    )
+    # Workers can write inside their workspace, but not to its parent.
+    tmp_path.chmod(0o500)
+    try:
+        log_path, downloaded = run_lammps_in_modal(
+            workspace,
+            "run.in",
+            volume=volume,
+            remote_function=function,
+            job_id="job-1",
+        )
+    finally:
+        tmp_path.chmod(0o700)
 
+    current_stat = workspace.stat()
+    assert current_stat.st_ino == original_stat.st_ino
+    assert current_stat.st_mode == original_stat.st_mode
+    assert current_stat.st_uid == original_stat.st_uid
+    assert current_stat.st_gid == original_stat.st_gid
+    assert list(tmp_path.iterdir()) == [workspace]
+    assert sorted(path.name for path in workspace.iterdir()) == [
+        "run.in",
+        "run.log",
+        "structure.data",
+        "trajectory.dump",
+    ]
     assert log_path == workspace / "run.log"
     assert downloaded == 4
     assert (workspace / "run.in").read_text() == "read_data structure.data\n"
@@ -136,6 +161,128 @@ def test_modal_lammps_round_trip_replaces_local_workspace(tmp_path: Path) -> Non
     ]
     assert volume.removed == ["/corral/jobs/job-1"]
     assert volume.files == {}
+
+
+def test_modal_sync_preserves_and_excludes_runtime_directories(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "inputs").mkdir()
+    (workspace / "inputs/run.in").write_text("run 1\n")
+    private_names = (f"{SCRATCH_PREFIX}worker", NODE_WORKSPACE_DIR)
+    for name in private_names:
+        private = workspace / name
+        private.mkdir()
+        (private / "secret").write_text("private runtime data")
+        (private / "alias").symlink_to("secret")
+
+    volume = _Volume()
+    function = _RemoteFunction(volume)
+    run_lammps_in_modal(
+        workspace,
+        "inputs/run.in",
+        volume=volume,
+        remote_function=function,
+        job_id="runtime",
+    )
+
+    assert function.uploaded_files == {"/corral/jobs/runtime/inputs/run.in": b"run 1\n"}
+    for name in private_names:
+        assert (workspace / name / "secret").read_text() == "private runtime data"
+        assert (workspace / name / "alias").is_symlink()
+    assert {path.name for path in workspace.iterdir()} == {
+        *private_names,
+        "inputs",
+        "run.log",
+        "trajectory.dump",
+    }
+
+
+@pytest.mark.parametrize("failure", ["download", "publish"])
+def test_modal_sync_failure_preserves_original_workspace(
+    tmp_path, monkeypatch, failure
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "run.in").write_text("run 1\n")
+    (workspace / "old").mkdir()
+    (workspace / "old/data").write_text("original")
+    volume = _Volume()
+
+    if failure == "download":
+
+        def fail_download(_path):
+            yield b"partial"
+            raise OSError("download interrupted")
+
+        monkeypatch.setattr(volume, "read_file", fail_download)
+    else:
+        replace = Path.replace
+
+        def fail_publish(source, target):
+            if source.name == "trajectory.dump" and source.parent != workspace:
+                raise OSError("publish interrupted")
+            return replace(source, target)
+
+        monkeypatch.setattr(Path, "replace", fail_publish)
+
+    with pytest.raises(RuntimeError, match=f"{failure} interrupted"):
+        run_lammps_in_modal(
+            workspace,
+            "run.in",
+            volume=volume,
+            remote_function=_RemoteFunction(volume),
+            job_id="failure",
+        )
+
+    assert (workspace / "run.in").read_text() == "run 1\n"
+    assert (workspace / "old/data").read_text() == "original"
+    assert {path.name for path in workspace.iterdir()} == {"run.in", "old"}
+    assert volume.removed == []
+
+
+def test_modal_publish_applies_remote_deletions_without_replacing_root(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "deleted").write_text("old")
+    (workspace / "changed").mkdir()
+    (workspace / "changed/old").write_text("old")
+    staging = workspace / f"{SCRATCH_PREFIX}modal-test" / "workspace"
+    staging.mkdir(parents=True)
+    (staging / "changed").write_text("now a file")
+
+    _publish_workspace(staging, workspace)
+
+    assert not (workspace / "deleted").exists()
+    assert (workspace / "changed").read_text() == "now a file"
+    assert staging.is_dir()
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    ["../outside", f"{SCRATCH_PREFIX}worker/secret", f"{NODE_WORKSPACE_DIR}/secret"],
+)
+def test_modal_sync_rejects_unsafe_download_paths(tmp_path, monkeypatch, suffix):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "run.in").write_text("run 1\n")
+    volume = _Volume()
+    monkeypatch.setattr(
+        volume,
+        "listdir",
+        lambda *_args, **_kwargs: [_Entry(f"/corral/jobs/unsafe/{suffix}", 0)],
+    )
+
+    with pytest.raises(RuntimeError, match="unsafe workspace path"):
+        run_lammps_in_modal(
+            workspace,
+            "run.in",
+            volume=volume,
+            remote_function=_RemoteFunction(volume),
+            job_id="unsafe",
+        )
+
+    assert (workspace / "run.in").read_text() == "run 1\n"
+    assert list(workspace.iterdir()) == [workspace / "run.in"]
 
 
 def test_failed_modal_run_still_downloads_diagnostics(tmp_path: Path) -> None:

--- a/tasks/ml/src/ml/tools.py
+++ b/tasks/ml/src/ml/tools.py
@@ -311,7 +311,7 @@ def get_bulk_polymorphs_data(composition: str) -> str:
         return json.dumps(polymorph_data, indent=2)
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def get_bulk_polymorphs_data_to_file(
     composition: str, save_path: str | None = None, work_dir: str | None = None
 ) -> str:
@@ -464,7 +464,7 @@ def get_bulk_polymorphs_data_to_file(
         return save_path
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def batch_retrieve_polymorphs(
     compositions: list[str],
     max_energy_above_hull: float = 0.5,
@@ -847,7 +847,7 @@ def select_polymorphs_with_strategy(
     return json.dumps(selected, indent=2)
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def consolidate_polymorph_datasets(
     composition_files: str,
     output_path: str = "consolidated_polymorphs.json",
@@ -981,7 +981,7 @@ def consolidate_polymorph_datasets(
     )
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def select_polymorphs_with_strategy_to_file(
     polymorphs_data: str,
     save_path: str,
@@ -1139,7 +1139,7 @@ def select_polymorphs_with_strategy_to_file(
     return save_path
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def filter_json_with_strategy(
     input_json_path: str,
     output_json_path: str,
@@ -1295,7 +1295,7 @@ Dataset preparation tools for different ML model types.
 """
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def prepare_tabular_dataset(
     polymorphs_json_path: str,
     output_path: str,
@@ -1737,7 +1737,7 @@ def get_mp_thermo_data(material_id: str) -> str:
 """
 
 
-@tool(hidden_args=["work_dir"])
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
 def train_xgboost_model(
     train_data_path: str,
     test_data_path: str,

--- a/tasks/spectra_elucidation/spectra_elucidation/tools.py
+++ b/tasks/spectra_elucidation/spectra_elucidation/tools.py
@@ -418,7 +418,7 @@ def retrieve_carbon_shifts() -> str:
     )
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def carbon_nmr_spectra(h_smiles: str) -> str:
     """[BRIEF] Return the 13C NMR spectra for the sample at hand. [/BRIEF]
 
@@ -472,7 +472,7 @@ def carbon_nmr_spectra(h_smiles: str) -> str:
     return asyncio.run(SpectraAPI.get_c13_nmr_prediction(h_smiles))
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def proton_nmr_spectra(h_smiles: str) -> str:
     """[BRIEF] Returns the 1H NMR spectra for a given SMILES string. [/BRIEF]
 
@@ -524,7 +524,7 @@ def proton_nmr_spectra(h_smiles: str) -> str:
     return asyncio.run(SpectraAPI.get_h_nmr_prediction(h_smiles))
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def ir_spectra(h_smiles: str) -> str:
     """[BRIEF] Returns the IR spectra for the sample at hand. This spectra may not be accurate for all compounds. It works best for identifying functional groups such as C=O. [/BRIEF]
 
@@ -576,7 +576,7 @@ def ir_spectra(h_smiles: str) -> str:
     return asyncio.run(SpectraAPI.get_ir_prediction(h_smiles))
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def hsqc_nmr_spectra(h_smiles: str) -> str:
     """[BRIEF] Returns the HSQC (Heteronuclear Single Quantum Coherence) NMR spectra for the sample at hand. [/BRIEF]
 
@@ -639,7 +639,7 @@ def hsqc_nmr_spectra(h_smiles: str) -> str:
     return "No HSQC spectrum found for the provided SMILES."
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def mass_spectrometry_spectra(h_smiles: str) -> str:
     """[BRIEF] Returns the mass spectrometry spectra for the sample at hand using the Electrospray Ionization (ESI) technique. [/BRIEF]
 
@@ -1040,7 +1040,7 @@ def validate_smiles(smiles: str) -> bool:
     return mol is not None
 
 
-@tool(hidden_args=["h_smiles"])
+@tool(hidden_args=["h_smiles"], trusted=True)
 def return_possible_fragments(h_smiles: str) -> list[str]:
     """[BRIEF] Return a list of fragments of the sample at hand by removing one or two atoms from the molecule. [/BRIEF]
 

--- a/tasks/wetlab/wetlab/engine.py
+++ b/tasks/wetlab/wetlab/engine.py
@@ -19,6 +19,9 @@ from wetlab.colors import (
 )
 
 WETCHEM_PATH = Path(__file__).with_name("WetChem.yaml")
+# Public chemistry data must be loaded by the trusted bootstrap. Tool workers
+# cannot reopen the private task package after dropping their Unix identity.
+_WETCHEM_CONTENTS = WETCHEM_PATH.read_bytes()
 ZERO = 1e-20
 
 
@@ -84,7 +87,7 @@ def _reaktoro_version() -> str:
 
 
 def _database_sha256() -> str:
-    return hashlib.sha256(WETCHEM_PATH.read_bytes()).hexdigest()
+    return hashlib.sha256(_WETCHEM_CONTENTS).hexdigest()
 
 
 def _json_copy(value: Any) -> Any:
@@ -206,7 +209,7 @@ class WetlabEngine:
     def __init__(self, spec: ChemicalSystemSpec):
         spec.assert_compatible()
         self.spec = spec
-        database = rk.Database.fromFile(str(WETCHEM_PATH))
+        database = rk.Database.fromStringYAML(_WETCHEM_CONTENTS.decode("utf-8"))
         aqueous_phase = rk.AqueousPhase(_speciate(spec.elements))
         try:
             self.system = rk.ChemicalSystem(database, aqueous_phase, rk.MineralPhases())

--- a/tasks/wetlab/wetlab/tools.py
+++ b/tasks/wetlab/wetlab/tools.py
@@ -170,7 +170,7 @@ def possible_anions() -> str:
     return " ".join(ANIONS)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def measure_pH(wetlab, label: str) -> str:
     """[BRIEF] Measures the pH of the solution using a pH paper.[/BRIEF]
 
@@ -248,7 +248,7 @@ def measure_pH(wetlab, label: str) -> str:
     return round(pH)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def perform_flame_test(wetlab, label: str) -> str:
     """[BRIEF] Performs a flame test on the solution. Cost = 1 mL [/BRIEF]
 
@@ -396,7 +396,7 @@ def lookup_flame_colors() -> str:
     return "\n".join(flame_colors)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def checkout_color(wetlab, label: str) -> str:
     """[BRIEF] Observe the color of a solution or precipitate. [/BRIEF]
 
@@ -614,7 +614,7 @@ def simulate_color_mixture(mixture: list[tuple[str, float]]) -> str:
     return closest_color_names(result_hex, mode="precipitate", max_names=1)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def get_available_reagents(wetlab) -> str:
     """[BRIEF] Returns the list of available reagent solutions. [/BRIEF]
 
@@ -676,7 +676,7 @@ def get_available_reagents(wetlab) -> str:
         return note + "\n".join(reagent_descriptions)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def mix_two_solutions(
     wetlab,
     test_label: str,
@@ -837,7 +837,7 @@ def mix_two_solutions(
     return "\n".join(observations)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def add_a_solution(
     wetlab, test_label: str, sol1_label: str, sol2_label: str, sol2_vol: int
 ) -> str:
@@ -1087,7 +1087,7 @@ def add_a_solution(
     return "\n".join(observations)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def filter_solution(wetlab, label: str) -> str:
     """[BRIEF] Separates the precipitate from the supernatant solution. [/BRIEF]
 
@@ -1173,7 +1173,7 @@ def filter_solution(wetlab, label: str) -> str:
             return "The target solution has no visible precipitate to filter! No change was made to the Inventory."
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def add_precipitate_to_solution(
     wetlab, test_label: str, prec_label: str, sol_label: str, sol_vol: int
 ) -> str:
@@ -1382,7 +1382,7 @@ def add_precipitate_to_solution(
     return "\n".join(observations)
 
 
-@tool(hidden_args=["wetlab"])
+@tool(hidden_args=["wetlab"], trusted=True)
 def check_inventory(wetlab) -> str:
     """[BRIEF] Returns the current contents of the Inventory [/BRIEF]
 

--- a/tests/agents/ai_scientist/test_execution_pool.py
+++ b/tests/agents/ai_scientist/test_execution_pool.py
@@ -123,6 +123,24 @@ def execute_and_commit(pool, branch, experiment_node):
     pool.commit(branch, experiment_node, start)
 
 
+def test_node_workspaces_clone_instead_of_reusing_a_completed_node():
+    sessions = CloneableSessions()
+    sessions.isolated_node_workspaces = True
+    pool = ExecutionPool(sessions=sessions, tools=TOOLS, max_tool_calls=10)
+    tree = ExperimentTree()
+    first = pool.create()
+    parent = node("node_1", first, [action("set", 3)])
+    tree.add(parent)
+    execute_and_commit(pool, first, parent)
+    assert pool.replay_cost(parent, tree, prefer_existing=True) == 0
+    second = pool.acquire(parent, tree, prefer_existing=True)
+    assert second.workspace != first.workspace
+    assert sessions.states[second.execution_id] == 3
+    second.executor.execute_plan([action("set", 7)])
+    assert sessions.states[first.execution_id] == 3
+    assert pool.executions_cloned == 1
+
+
 def test_execution_pool_uses_a_ready_action_native_branch_session():
     sessions = ReadySessions()
     pool = ExecutionPool(

--- a/tests/agents/test_openhands.py
+++ b/tests/agents/test_openhands.py
@@ -62,6 +62,7 @@ async def test_openhands_uses_only_the_iteration_run_limit(monkeypatch, tmp_path
             self,
             *,
             agent,
+            mcp_tool_provider,
             callbacks,
             token_callbacks,
             workspace,
@@ -73,6 +74,7 @@ async def test_openhands_uses_only_the_iteration_run_limit(monkeypatch, tmp_path
             captured.update(
                 {
                     "agent": agent,
+                    "mcp_tool_provider": mcp_tool_provider,
                     "callbacks": callbacks,
                     "token_callbacks": token_callbacks,
                     "workspace": workspace,
@@ -96,7 +98,7 @@ async def test_openhands_uses_only_the_iteration_run_limit(monkeypatch, tmp_path
         def close(self):
             captured["closed"] = True
 
-    monkeypatch.setattr(openhands_module, "Conversation", FakeConversation)
+    monkeypatch.setattr(openhands_module, "LocalConversation", FakeConversation)
     monkeypatch.setattr(
         OpenHandsAgent,
         "_make_llm",
@@ -120,6 +122,7 @@ async def test_openhands_uses_only_the_iteration_run_limit(monkeypatch, tmp_path
     )
 
     assert captured["max_iteration_per_run"] == 7
+    assert captured["mcp_tool_provider"].tool_timeout_s == agent.tool_timeout_s
     assert captured["stuck_detection"] is False
     assert len(captured["token_callbacks"]) == 1
     assert captured["token_callbacks"][0](object()) is None

--- a/tests/agents/test_openhands_sdk_integration.py
+++ b/tests/agents/test_openhands_sdk_integration.py
@@ -12,12 +12,16 @@ The `openhands` extra is gated to Python >= 3.12, so the whole module is
 skipped when the SDK is not importable.
 """
 
+import asyncio
+
+import anyio
+import httpx
 import pytest
 from pydantic import ValidationError
 
 pytest.importorskip("openhands.sdk")
 
-from openhands.sdk import AgentContext
+from openhands.sdk import AgentContext, LocalConversation
 from openhands.sdk.mcp.definition import (
     MCPToolAction,
     MCPToolObservation,
@@ -25,9 +29,13 @@ from openhands.sdk.mcp.definition import (
 from openhands.sdk.mcp.tool import MCP_TOOL_TIMEOUT_SECONDS
 
 from corral.agents.openhands import (
-    _OPENHANDS_EXECUTOR_TIMEOUT_S,
+    _OPENHANDS_DEFAULT_EXECUTOR_TIMEOUT_S,
     OpenHandsAgent,
+    _TimeoutMCPToolProvider,
 )
+from corral.backend.mcp import open_mcp_host
+from corral.core.tool import ToolResponse
+from corral.core.tool_catalog import ToolCatalogSnapshot
 
 
 def test_action_arguments_reads_real_mcp_tool_action_data():
@@ -61,15 +69,84 @@ def test_agent_context_datetime_none_omits_datetime_block():
 
 
 def test_executor_timeout_constant_tracks_installed_sdk():
-    """The recorded executor cap is read from the SDK, not hard-coded."""
-    assert float(MCP_TOOL_TIMEOUT_SECONDS) == _OPENHANDS_EXECUTOR_TIMEOUT_S
+    """Retain the SDK default separately from the configured execution limit."""
+    assert float(MCP_TOOL_TIMEOUT_SECONDS) == _OPENHANDS_DEFAULT_EXECUTOR_TIMEOUT_S
 
 
 def test_default_tool_timeout_is_enforceable_end_to_end():
-    """The default per-call timeout equals the cap OpenHands can actually enforce."""
+    """Use twice the longest complete MD call, rounded up to whole seconds."""
     agent = OpenHandsAgent(model="openai/gpt-5.6")
-    assert agent.tool_timeout_s == float(MCP_TOOL_TIMEOUT_SECONDS)
-    assert agent.effective_tool_timeout_s == float(MCP_TOOL_TIMEOUT_SECONDS)
+    assert agent.tool_timeout_s == 1202
+    assert agent.effective_tool_timeout_s == 1202
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("nan"), float("inf")])
+def test_invalid_tool_timeout_is_rejected(timeout):
+    with pytest.raises(ValueError, match="finite and positive"):
+        OpenHandsAgent(tool_timeout_s=timeout)
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@pytest.mark.parametrize("tool_timeout", [1202, 1800])
+async def test_real_mcp_call_uses_configured_transport_and_executor_timeouts(
+    monkeypatch, tmp_path, tool_timeout
+):
+    """Exercise the SDK provider hook and inspect actual HTTP request deadlines."""
+    read_timeouts = []
+    original_send = httpx.AsyncClient.send
+
+    async def capture_send(self, request, **kwargs):
+        read_timeouts.append(request.extensions.get("timeout", {}).get("read"))
+        return await original_send(self, request, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", capture_send)
+    # Native tools are irrelevant to a timeout test and require Chromium.
+    monkeypatch.setattr("corral.agents.openhands.get_default_tools", list)
+    schema = {
+        "type": "function",
+        "function": {
+            "name": "measure",
+            "description": "A slow local measurement",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    async def execute(action):
+        assert action.name == "measure"
+        await asyncio.sleep(0.02)
+        return ToolResponse(success=True, result="measured", error=None)
+
+    async with (
+        open_mcp_host() as host,
+        host.bind(
+            catalog=ToolCatalogSnapshot.capture((schema,)), execute=execute
+        ) as endpoint,
+    ):
+        adapter = OpenHandsAgent(api_key="offline-test", tool_timeout_s=tool_timeout)
+        agent = adapter._build_agent(adapter._make_llm(), endpoint.url, False)
+
+        def call_tool():
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=str(tmp_path),
+                visualizer=None,
+                persistence_dir=None,
+                mcp_tool_provider=_TimeoutMCPToolProvider(adapter.tool_timeout_s),
+            )
+            try:
+                conversation.send_message("Initialize tools without calling a model")
+                tool = conversation.state.agent.tools_map["measure"]
+                assert tool.executor.timeout == tool_timeout
+                observation = tool(MCPToolAction(data={}))
+                assert not observation.is_error
+                assert observation.content[-1].text == "measured"
+            finally:
+                conversation.close()
+
+        await anyio.to_thread.run_sync(call_tool)
+    assert read_timeouts
+    assert all(value == tool_timeout for value in read_timeouts)
 
 
 def test_reasoning_effort_is_applied_to_real_llm():
@@ -108,4 +185,22 @@ def test_agent_uses_openhands_native_default_tools():
         "task_tracker",
         "browser_tool_set",
     ]
+    assert agent.include_default_tools == ["FinishTool", "ThinkTool"]
+
+
+def test_task_terminal_does_not_collide_with_openhands_native_terminal():
+    """Docker's MCP terminal must not collide with the SDK terminal preset."""
+    adapter = OpenHandsAgent(model="openai/gpt-5.6", api_key="x")
+    agent = adapter._build_agent(
+        adapter._make_llm(),
+        "http://127.0.0.1:1234/mcp",
+        enable_surrender=False,
+        mcp_tool_names={"terminal", "submit_answer"},
+    )
+    assert [tool.name for tool in agent.tools] == [
+        "file_editor",
+        "task_tracker",
+        "browser_tool_set",
+    ]
+    assert agent.mcp_config["corral"].url == "http://127.0.0.1:1234/mcp"
     assert agent.include_default_tools == ["FinishTool", "ThinkTool"]

--- a/tests/agents/test_reflexion_agent.py
+++ b/tests/agents/test_reflexion_agent.py
@@ -7,7 +7,7 @@ import pytest
 from corral.agents.reflection import ReflectionModule
 from corral.agents.reflexion_agent import ReflexionAgent
 from corral.agents.schema import AgentOutcome, AgentUsage
-from corral.agents.session import ToolResponse
+from corral.agents.session import AgentSession, ToolResponse
 from corral.core.action import SUBMIT_ANSWER_TOOL_NAME, Action
 
 
@@ -41,6 +41,9 @@ class Actor:
 class FakeSession:
     prompt = "solve"
     execution_id = "execution-1"
+    model_name = AgentSession.model_name
+    previous_messages = AgentSession.previous_messages
+    previous_commit_hash = AgentSession.previous_commit_hash
 
     def __init__(
         self,

--- a/tests/agents/test_session.py
+++ b/tests/agents/test_session.py
@@ -1,0 +1,113 @@
+"""Regression tests for workspace restoration in async agent sessions."""
+
+from pathlib import Path
+
+import anyio
+import pytest
+
+from corral.agents.schema import AgentOutcome
+from corral.agents.session import AgentSession, run_agent_session
+from corral.core import ActorRef, AgentStarted, CommitRequest
+from corral.core.environment import Environment
+from corral.core.task import TaskDefinition
+from corral.persistence import SQLiteCommitStore
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture()
+async def workspace_session(tmp_path):
+    environment = Environment(
+        "workspace-task",
+        TaskDefinition(
+            name="workspace-task",
+            description="Read the restored workspace.",
+            tools=[],
+            scoring_fn=lambda _answer: 1.0,
+            submission_format={"answer": "string"},
+            resolve_answer=False,
+        ),
+        base_work_dir=str(tmp_path / "workspaces"),
+        task_execution_id="workspace-execution",
+    )
+    (Path(environment.workspace_path) / "notes.txt").write_text(
+        "restored contents", encoding="utf-8"
+    )
+    runtime_actor = ActorRef(kind="runtime", actor_id="corral", run_id="runtime")
+    actor = ActorRef(kind="agent", actor_id="test-agent", run_id="agent")
+    event = await anyio.to_thread.run_sync(
+        lambda: environment.initial_event(
+            execution_id="workspace-execution", actor_id=actor.actor_id
+        )
+    )
+    async with SQLiteCommitStore(
+        tmp_path / "commits.sqlite3", "workspace-execution"
+    ) as store:
+        root = await store.append(
+            CommitRequest(
+                request_id="execution:started",
+                branch_id="main",
+                based_on_hash=None,
+                author=runtime_actor,
+                event=event,
+            )
+        )
+        await store.append(
+            CommitRequest(
+                request_id="agent:started",
+                branch_id="main",
+                based_on_hash=root.hash,
+                author=runtime_actor,
+                event=AgentStarted(agent_run_id=actor.run_id, agent_id=actor.actor_id),
+            )
+        )
+        state = await store.materialize("main")
+        assert "notes.txt" in state.workspace.files
+        yield AgentSession(
+            environment,
+            state,
+            actor=actor,
+            runtime_actor=runtime_actor,
+            state_store=store,
+            max_iterations=10,
+        )
+
+
+@pytest.mark.anyio()
+async def test_run_agent_session_restores_nonempty_workspace(workspace_session):
+    session = workspace_session
+    restored_file = Path(session.workspace) / "notes.txt"
+    restored_file.unlink()
+
+    class Reader:
+        async def run_session(self, session):
+            assert restored_file.read_text(encoding="utf-8") == "restored contents"
+            return AgentOutcome(status="iteration_limit", error="budget ended")
+
+    result = await run_agent_session(
+        Reader(),
+        session.environment,
+        session.state,
+        actor=session.actor,
+        state_store=session.state_store,
+        max_iterations=10,
+    )
+
+    assert result.state.workspace == session.state.workspace
+
+
+@pytest.mark.anyio()
+async def test_fork_branch_restores_nonempty_workspace(workspace_session):
+    session = workspace_session
+
+    fork = await session.fork_branch(branch_id="experiment")
+
+    assert fork.workspace != session.workspace
+    assert fork.state.workspace == session.state.workspace
+    assert (
+        Path(fork.workspace, "notes.txt").read_text(encoding="utf-8")
+        == "restored contents"
+    )

--- a/tests/agents/test_session.py
+++ b/tests/agents/test_session.py
@@ -1,13 +1,16 @@
 """Regression tests for workspace restoration in async agent sessions."""
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import anyio
 import pytest
+from anyio.from_thread import BlockingPortal
 
+from corral.agents.ai_scientist.agent import _BranchSessionRegistry
 from corral.agents.schema import AgentOutcome
 from corral.agents.session import AgentSession, run_agent_session
-from corral.core import ActorRef, AgentStarted, CommitRequest
+from corral.core import Action, ActorRef, AgentStarted, CommitRequest
 from corral.core.environment import Environment
 from corral.core.task import TaskDefinition
 from corral.persistence import SQLiteCommitStore
@@ -111,3 +114,78 @@ async def test_fork_branch_restores_nonempty_workspace(workspace_session):
         Path(fork.workspace, "notes.txt").read_text(encoding="utf-8")
         == "restored contents"
     )
+
+
+@pytest.mark.anyio()
+async def test_scientist_nodes_have_independent_files_and_promote_the_winner(
+    workspace_session, monkeypatch
+):
+    parent = workspace_session
+    Path(parent.workspace, "live.txt").write_text("live contents")
+    shutdown_jobs = Mock()
+    monkeypatch.setattr(parent.environment, "shutdown_jobs", shutdown_jobs)
+
+    async with BlockingPortal() as portal:
+        sessions = _BranchSessionRegistry(parent, portal)
+        first = await anyio.to_thread.run_sync(sessions.create_branch)
+        second = await anyio.to_thread.run_sync(sessions.create_branch)
+
+        async def write(branch, content):
+            response = await anyio.to_thread.run_sync(
+                lambda: branch.execute(
+                    Action(
+                        name="write_file",
+                        arguments={"path": "model.txt", "content": content},
+                    )
+                )
+            )
+            assert response.success, response
+
+        await write(first, "winning model")
+        await write(second, "losing model")
+        clone = await anyio.to_thread.run_sync(
+            sessions.clone_branch, first.execution_id
+        )
+        assert Path(clone.workspace, "model.txt").read_text() == "winning model"
+        await write(clone, "changed clone")
+        assert len({branch.workspace for branch in (first, second, clone)}) == 3
+        closed = []
+        for branch in (first, second, clone):
+            assert Path(branch.workspace).parent == Path(
+                parent.workspace, ".corral-nodes"
+            )
+            branch_session = sessions.session(branch.execution_id)
+            assert branch_session.environment is not parent.environment
+            assert Path(branch.workspace, "live.txt").read_text() == "live contents"
+            assert not Path(branch.workspace, ".corral-nodes").exists()
+            mocked = Mock()
+            monkeypatch.setattr(branch_session.environment, "shutdown_jobs", mocked)
+            closed.append(mocked)
+        assert Path(first.workspace, "model.txt").read_text() == "winning model"
+        assert Path(second.workspace, "model.txt").read_text() == "losing model"
+        assert not Path(parent.workspace, "model.txt").exists()
+        assert parent.state.tool_statistics == {}
+
+        response = await anyio.to_thread.run_sync(
+            lambda: first.execute(
+                Action(
+                    name="read_file",
+                    arguments={
+                        "path": "../" + Path(second.workspace).name + "/model.txt"
+                    },
+                )
+            )
+        )
+        assert not response.success
+        promoted = await anyio.to_thread.run_sync(
+            sessions.promote_branch_artifacts, first.execution_id, parent.execution_id
+        )
+        assert set(promoted["files"]) == {"notes.txt", "live.txt", "model.txt"}
+        assert Path(parent.workspace, "model.txt").read_text() == "winning model"
+        snapshot = await parent.environment.workspace_manager.snapshot(parent.workspace)
+        assert set(snapshot.files) == {"notes.txt", "live.txt", "model.txt"}
+        for branch in (first, second, clone):
+            await anyio.to_thread.run_sync(sessions.close_branch, branch.execution_id)
+        for mocked in closed:
+            mocked.assert_called_once_with()
+        shutdown_jobs.assert_not_called()

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -206,6 +206,7 @@ async def test_llm_call_basic(monkeypatch):
         model="gpt-3.5-turbo",
         messages=messages,
         temperature=0.7,
+        tools=None,
         api_base=None,
         stream=True,
     )
@@ -215,15 +216,26 @@ async def test_llm_call_basic(monkeypatch):
 
 
 @pytest.mark.anyio()
-async def test_llm_call_with_tools(monkeypatch):
-    """Test llm_call with tools."""
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        None,
+        "auto",
+        "none",
+        "required",
+        {"type": "function", "function": {"name": "test_tool"}},
+    ],
+)
+async def test_llm_call_with_tools(monkeypatch, tool_choice):
+    """Leave tool selection to LiteLLM unless the caller specifies a choice."""
     mock_litellm, mock_response = setup_mock_litellm(monkeypatch)
 
     messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
     tools = [{"type": "function", "function": {"name": "test_tool"}}]
+    kwargs = {} if tool_choice is None else {"tool_choice": tool_choice}
 
     result = await llm_call(
-        model="gpt-3.5-turbo", messages=messages, temperature=0.7, tools=tools
+        model="gpt-3.5-turbo", messages=messages, temperature=0.7, tools=tools, **kwargs
     )
 
     # Check that result is LLMResponse wrapper
@@ -235,15 +247,15 @@ async def test_llm_call_with_tools(monkeypatch):
         messages=messages,
         temperature=0.7,
         tools=tools,
-        tool_choice="auto",
         api_base=None,
         stream=True,
+        **kwargs,
     )
 
 
 @pytest.mark.anyio()
 async def test_llm_call_anthropic_model(monkeypatch):
-    """Test llm_call with anthropic model adds max_tokens."""
+    """Leave the default token limit to LiteLLM's provider adapter."""
     mock_litellm, mock_response = setup_mock_litellm(monkeypatch)
 
     messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
@@ -260,62 +272,63 @@ async def test_llm_call_anthropic_model(monkeypatch):
         model="anthropic/claude-3-sonnet",
         messages=messages,
         temperature=0.7,
-        max_tokens=8192,
+        tools=None,
         api_base=None,
         stream=True,
     )
 
 
 @pytest.mark.anyio()
-async def test_llm_call_reasoning_effort_forces_temperature_one(monkeypatch):
-    """Reasoning effort must override temperature to 1 (Anthropic thinking rule)."""
-    mock_litellm, _ = setup_mock_litellm(monkeypatch)
-
-    messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
-
-    await llm_call(
-        model="anthropic/claude-3-sonnet",
-        messages=messages,
-        temperature=0.0,
-        reasoning_effort="medium",
-    )
-
-    # Anthropic rejects any temperature other than 1 when thinking is enabled,
-    # so the requested 0.0 is overridden to 1 while reasoning_effort passes through.
-    mock_litellm.acompletion.assert_awaited_once_with(
-        model="anthropic/claude-3-sonnet",
-        messages=messages,
-        temperature=1,
-        max_tokens=8192,
-        api_base=None,
-        reasoning_effort="medium",
-        stream=True,
-    )
-
-
-@pytest.mark.anyio()
-async def test_llm_call_routes_gpt_5_6_reasoning_tools_to_responses(monkeypatch):
-    """GPT-5.6 reasoning plus tools uses the provider's Responses endpoint."""
+@pytest.mark.parametrize(
+    ("model", "temperature", "kwargs"),
+    [
+        ("openai/gpt-5.6-terra", 0.2, {"reasoning_effort": "none"}),
+        ("openai/responses/gpt-5.6-terra", None, {"reasoning_effort": "high"}),
+        (
+            "anthropic/claude-sonnet-4-20250514",
+            None,
+            {"reasoning_effort": "high", "max_tokens": 32768},
+        ),
+        (
+            "anthropic/claude-sonnet-4-20250514",
+            1.0,
+            {
+                "thinking": {"type": "enabled", "budget_tokens": 1024},
+                "max_tokens": 4096,
+            },
+        ),
+        ("anthropic/claude-sonnet-4-20250514", 0.3, {"thinking": {"type": "disabled"}}),
+        (
+            "deepseek/deepseek-reasoner",
+            0.5,
+            {"reasoning_effort": "high", "drop_params": True},
+        ),
+    ],
+)
+async def test_llm_call_preserves_model_configuration(
+    monkeypatch, model, temperature, kwargs
+):
+    """Provider configuration must survive without model-name overrides."""
     mock_litellm, _ = setup_mock_litellm(monkeypatch)
     messages = cast("list[LiteLLMMessage]", [{"role": "user", "content": "Hello"}])
     tools = [{"type": "function", "function": {"name": "submit_answer"}}]
 
     await llm_call(
-        model="openai/gpt-5.6-terra",
+        model=model,
         messages=messages,
         tools=tools,
-        temperature=1.0,
-        reasoning_effort="none",
+        temperature=temperature,
+        **kwargs,
     )
 
     mock_litellm.acompletion.assert_awaited_once_with(
-        model="openai/responses/gpt-5.6-terra",
+        model=model,
         messages=messages,
-        temperature=1,
         tools=tools,
+        temperature=temperature,
         api_base=None,
-        reasoning_effort="none",
         stream=True,
+        **kwargs,
     )
 
 

--- a/tests/orchestration/test_docker_launcher.py
+++ b/tests/orchestration/test_docker_launcher.py
@@ -47,6 +47,12 @@ def test_docker_benchmark_accepts_complete_runtime_definitions():
     assert request.sandbox.mode == SandboxMode.DOCKER.value
 
 
+@pytest.mark.parametrize("version", ["1", "2", "3"])
+def test_legacy_runtime_cannot_disable_worker_permissions(version):
+    with pytest.raises(ValueError, match="rebuild the image"):
+        DockerSandboxSpec(runtime_protocol_version=version)
+
+
 def test_restore_host_ownership_uses_os_chown(monkeypatch, tmp_path):
     checkpoint = tmp_path / "checkpoint"
     checkpoint.mkdir()
@@ -81,6 +87,7 @@ async def test_docker_launcher_uses_one_hardened_container_and_host_shard(
         commands.append(arguments)
         operation = arguments[1:3]
         if arguments[1] == "create":
+            assert execution_dir.stat().st_mode & 0o7777 == 0o700
             return 0, "container-id"
         if operation == ("start", "--attach"):
             result = StateRef(
@@ -130,9 +137,18 @@ async def test_docker_launcher_uses_one_hardened_container_and_host_shard(
     assert durable_metadata["sandbox"]["final_commit_hash"] == "a" * 64
     create = next(command for command in commands if command[1] == "create")
     assert "--read-only" in create
-    assert create[
-        create.index("--security-opt") : create.index("--security-opt") + 2
-    ] == ("--security-opt", "no-new-privileges")
+    assert "--init" in create
+    assert create[create.index("--user") + 1] == "0:0"
+    assert durable_metadata["sandbox"]["permissions_policy"] == "workspace-root-v1"
+    assert "SYS_ADMIN" in create
+    assert "SYS_CHROOT" in create
+    security_options = {
+        create[index + 1]
+        for index, argument in enumerate(create)
+        if argument == "--security-opt"
+    }
+    assert security_options == {"no-new-privileges", "apparmor=unconfined"}
+    assert "--privileged" not in create
     assert create[create.index("--cap-drop") : create.index("--cap-drop") + 2] == (
         "--cap-drop",
         "ALL",

--- a/tests/runtime/test_permissions.py
+++ b/tests/runtime/test_permissions.py
@@ -1,0 +1,1403 @@
+"""Exercise real Unix permission checks in the trial image (no model API calls).
+
+Run with CORRAL_PERMISSION_TESTS=1 inside the Docker image. Opting in makes
+missing root privileges or an incorrectly protected image a failure, not a skip.
+"""
+
+# Exercise imports after privilege dropping; SDK extras are optional locally.
+# ruff: noqa: PLC0415
+
+import os
+import threading
+
+import pytest
+
+from corral.agents.ai_scientist.agent import AIScientistAgent
+from corral.agents.session import AgentSessionCapabilities
+from corral.core.environment import Environment
+from corral.core.tool import tool
+from corral.runtime import permissions
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CORRAL_PERMISSION_TESTS") != "1",
+    reason="requires the real Docker trial permission boundary",
+)
+
+
+@pytest.fixture(autouse=True)
+def restricted_runtime(tmp_path):
+    assert os.geteuid() == 0
+    checkpoints = tmp_path / "checkpoints"
+    checkpoints.mkdir(mode=0o700)
+    permissions.configure(checkpoints)
+    yield
+    permissions._enabled = False
+
+
+@pytest.fixture()
+def workspace():
+    import tempfile
+
+    return tempfile.mkdtemp(prefix="permission-test-", dir="/workspace")
+
+
+@tool
+def permission_probe() -> str:
+    """Attempt reads and writes both directly and through detached descendants."""
+    import json
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    result = {"uid": os.getuid(), "gids": os.getgroups(), "denials": {}}
+    for target in (
+        "/opt/corral/pyproject.toml",
+        "/opt/corral/tasks",
+        "/corral-state",
+        "/etc/passwd",
+        "/proc/1/environ",
+    ):
+        try:
+            with open(target, "rb"):
+                pass
+        except (PermissionError, FileNotFoundError) as exc:
+            result["denials"][target] = str(exc)
+    for target in ("/opt/escape", "/escape"):
+        try:
+            Path(target).write_text("escaped")
+        except (PermissionError, OSError) as exc:
+            result["denials"][target] = str(exc)
+    Path("allowed.txt").write_text("workspace access")
+    result["workspace"] = Path("allowed.txt").read_text()
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os,pathlib; os.setsid(); pathlib.Path('/opt/corral/pyproject.toml').read_text()",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    result["child_error"] = child.stderr
+    result["child_returncode"] = child.returncode
+    try:
+        os.setuid(0)
+    except PermissionError:
+        result["cannot_regain_root"] = True
+    Path("source-link").symlink_to("/opt/corral/pyproject.toml")
+    try:
+        Path("source-link").read_text()
+    except PermissionError:
+        result["symlink_denied"] = True
+    finally:
+        Path("source-link").unlink()
+    return json.dumps(result)
+
+
+def assert_probe(result):
+    import json
+
+    probe = json.loads(result)
+    assert probe["uid"] != 0
+    assert probe["gids"] == []
+    assert len(probe["denials"]) == 7
+    assert probe["workspace"] == "workspace access"
+    assert probe["child_returncode"] != 0
+    assert "Permission denied" in probe["child_error"]
+    assert probe["cannot_regain_root"]
+    assert probe["symlink_denied"]
+
+
+def test_foreground_tool_and_descendants(workspace):
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    assert_probe(permissions.execute_tool(environment, None, permission_probe, {}))
+
+
+def test_terminal_inherits_worker_permissions(workspace):
+    import json
+    from pathlib import Path
+
+    from corral.workspace import WorkspaceFilesystem, build_terminal_tool
+
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    terminal = build_terminal_tool(WorkspaceFilesystem(workspace))
+    result = json.loads(
+        permissions.execute_tool(
+            environment,
+            None,
+            terminal,
+            {
+                "command": "id -u; printf 'workspace access' > allowed.txt; cat /opt/corral/pyproject.toml"
+            },
+        )
+    )
+
+    assert int(result["output"].splitlines()[0]) != 0
+    assert result["exit_code"] != 0
+    assert "Permission denied" in result["output"]
+    assert Path(workspace, "allowed.txt").read_text() == "workspace access"
+
+
+@tool
+def filesystem_root_probe() -> str:
+    """Probe unpublished paths, runtime aliases, and descriptor escapes."""
+    import ctypes
+    import errno
+    import json
+    import os
+    import sys
+    from pathlib import Path
+
+    runtime = Path("/workspace/.corral-runtime-system")
+    for alias in (
+        "/usr",
+        "/bin/sh",
+        "/dev/null",
+        "/proc",
+        "/etc/hosts",
+        sys.executable,
+    ):
+        assert Path(alias).resolve(strict=True).is_relative_to(runtime), alias
+    for target in (
+        "/outside-workspace.txt",
+        "/opt/unrelated/data.txt",
+        "/proc/1/root/outside-workspace.txt",
+        "/proc/self/root/outside-workspace.txt",
+        "/etc/hostname",
+    ):
+        try:
+            Path(target).read_bytes()
+        except (PermissionError, FileNotFoundError):
+            pass
+        else:
+            raise AssertionError(f"original image path is visible: {target}")
+
+    # Native libc calls must observe the same boundary as Python file APIs.
+    libc = ctypes.CDLL(None, use_errno=True)
+    assert libc.open(b"/outside-workspace.txt", os.O_RDONLY) == -1
+    assert ctypes.get_errno() in {errno.EACCES, errno.ENOENT}
+    link = Path("outside-link")
+    link.symlink_to("/outside-workspace.txt")
+    try:
+        try:
+            link.read_bytes()
+        except (PermissionError, FileNotFoundError):
+            pass
+        else:
+            raise AssertionError("workspace symlink exposed the original root")
+    finally:
+        link.unlink()
+
+    # No inherited log/directory handle may give access to a controller file.
+    for descriptor in Path("/proc/self/fd").iterdir():
+        try:
+            target = descriptor.readlink()
+        except FileNotFoundError:
+            continue
+        assert not str(target).startswith(
+            ("/corral-state", "/opt/corral", "/tmp/")
+        ), target
+    for alias in ("/tmp", "/dev/shm"):
+        target = Path(alias).resolve(strict=True)
+        assert target.is_relative_to(Path.cwd())
+        (target / "scratch-check").write_text("scratch")
+    with pytest.raises(OSError) as error:
+        Path("/usr/corral-write-check").write_text("forbidden")
+    assert error.value.errno in {errno.EACCES, errno.EROFS}
+    return json.dumps({"isolated_root": True})
+
+
+def test_original_container_paths_are_not_mounted(workspace):
+    import json
+    from pathlib import Path
+
+    # These sentinels are read-only mounts provided by the Docker test runner.
+    assert Path("/outside-workspace.txt").is_file()
+    assert Path("/opt/unrelated/data.txt").is_file()
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    result = permissions.execute_tool(environment, None, filesystem_root_probe, {})
+    assert json.loads(result) == {"isolated_root": True}
+
+
+def test_bootstrap_exit_kills_its_worker(tmp_path):
+    import signal
+    import time
+    from contextlib import suppress
+    from pathlib import Path
+
+    from corral.runtime._worker_filesystem import bind_bootstrap_parent
+
+    ready = tmp_path / "bootstrap-worker.pid"
+    bootstrap = os.fork()
+    if bootstrap == 0:
+        parent = os.getpid()
+        child = os.fork()
+        if child == 0:
+            bind_bootstrap_parent(parent)
+            temporary = ready.with_suffix(".tmp")
+            temporary.write_text(str(os.getpid()))
+            temporary.replace(ready)
+        while True:
+            signal.pause()
+    worker = None
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists():
+            if time.monotonic() > deadline:
+                pytest.fail("bootstrap worker did not start")
+            time.sleep(0.01)
+        worker = int(ready.read_text())
+        os.kill(bootstrap, signal.SIGKILL)
+        os.waitpid(bootstrap, 0)
+        bootstrap = None
+        while time.monotonic() < deadline:
+            try:
+                status = Path(f"/proc/{worker}/status").read_text()
+            except FileNotFoundError:
+                return
+            if status.split("State:", 1)[1].split()[0] == "Z":
+                return
+            time.sleep(0.01)
+        pytest.fail("worker survived the trusted bootstrap")
+    finally:
+        for pid in (bootstrap, worker):
+            if pid is not None:
+                with suppress(ProcessLookupError):
+                    os.kill(pid, signal.SIGKILL)
+        if bootstrap is not None:
+            os.waitpid(bootstrap, 0)
+
+
+def test_filesystem_setup_requires_privileges(workspace, tmp_path):
+    import errno
+
+    from corral.runtime._worker_filesystem import enter_workspace
+
+    child = os.fork()
+    if child == 0:
+        os.setgroups([])
+        os.setresgid(60000, 60000, 60000)
+        os.setresuid(60000, 60000, 60000)
+        try:
+            enter_workspace(
+                workspace, tmp_path / "jail", 60000, 60000, keep_fds={0, 1, 2}
+            )
+        except OSError as exc:
+            os._exit(0 if exc.errno == errno.EPERM else 1)
+        os._exit(1)
+    _, status = os.waitpid(child, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+    assert not (tmp_path / "jail").exists()
+
+
+@pytest.mark.parametrize("executor_name", ["thread", "process", "subprocess"])
+def test_background_executor_preferences_cannot_bypass_permissions(
+    workspace, executor_name
+):
+    from corral.backend.executors import JobWork, RestrictedExecutor
+    from corral.backend.jobs import JobManager
+
+    permission_probe.executor = executor_name
+    manager = JobManager()
+    executor = manager._resolve_executor(permission_probe)
+    assert isinstance(executor, RestrictedExecutor)
+    work = JobWork(
+        job_id="probe",
+        tool_name=permission_probe.name,
+        tool=permission_probe,
+        call_arguments={},
+        workspace=workspace,
+    )
+    assert_probe(executor.run_tool(work, threading.Event()))
+    manager.shutdown()
+
+
+class ProbeAgent:
+    tool_transport = "python"
+
+    async def run_session(self, session):
+        import json
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        from corral.agents.schema import AgentOutcome
+        from corral.core.action import Action
+
+        assert os.getuid() != 0
+        try:
+            Path("/opt/corral/tasks/wetlab/wetlab/env.py").read_text()
+        except PermissionError:
+            pass
+        else:
+            raise AssertionError("agent could inspect task source")
+        child = subprocess.run(  # noqa: ASYNC221 - intentionally test synchronous SDK-style spawning
+            [sys.executable, "-c", "import os; print(os.getuid())"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert int(child.stdout) == os.getuid()
+        answer = json.dumps({"uid": os.getuid(), "child_uid": int(child.stdout)})
+        await session.execute(
+            Action(name="submit_answer", arguments={"answer": answer})
+        )
+        return AgentOutcome(status="completed", answer=answer)
+
+
+class DelegatingProbeAgent:
+    tool_transport = "python"
+    session_capabilities = AgentSessionCapabilities(inspect_subagents=True)
+
+    async def run_session(self, session):
+        import os
+        from pathlib import Path
+
+        from corral.agents.schema import AgentOutcome
+        from corral.core.action import Action
+
+        class Child:
+            async def run_session(self, child_session):
+                assert os.getuid() != 0
+                try:
+                    Path("/opt/corral/pyproject.toml").read_text()
+                except PermissionError:
+                    return AgentOutcome(status="completed", answer="denied")
+                raise AssertionError("subagent could inspect source")
+
+        child_id = await session.spawn_subagent(Child(), handoff="probe")
+        outcome = await session.wait_for_subagent(child_id)
+        assert outcome.answer == "denied"
+        await session.execute(
+            Action(name="submit_answer", arguments={"answer": "denied"})
+        )
+        return AgentOutcome(status="completed", answer="denied")
+
+
+def native_agent_with_hooks():
+    from corral.agents.hooks import HookPoint
+    from corral.agents.tool_calling import ToolCallingAgent
+
+    def prepare(context):
+        import os
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        import corral.agents.tool_calling as native
+
+        assert os.getuid() != 0
+        with pytest.raises(PermissionError):
+            Path("/opt/corral/pyproject.toml").read_text()
+
+        async def reply(*args, **kwargs):
+            return SimpleNamespace(
+                content=None,
+                usage=None,
+                tool_calls=[
+                    {
+                        "id": "submission",
+                        "function": {
+                            "name": "submit_answer",
+                            "arguments": '{"answer":"native loop passed"}',
+                        },
+                    }
+                ],
+            )
+
+        native.call_model = reply
+        context.metadata["worker_uid"] = os.getuid()
+
+    agent = ToolCallingAgent(model="offline-test")
+    agent.hooks.register(HookPoint.BEFORE_TASK, prepare)
+    return agent
+
+
+def planner_agent_with_hooks():
+    from corral.agents.hooks import HookPoint
+    from corral.agents.llm_planner import LLMPlanner
+
+    def prepare(context):
+        import os
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        import corral.agents.base_agent as native
+
+        assert os.getuid() != 0
+        with pytest.raises(PermissionError):
+            Path("/opt/corral/src/corral/agents/prompts/index.json").read_text()
+        content = (
+            "Use the executor to submit the answer."
+            if isinstance(context.agent, LLMPlanner)
+            else (
+                "<action>submit_answer</action>"
+                '<action_input>{"answer":"planner delegate passed"}</action_input>'
+            )
+        )
+
+        async def reply(*args, **kwargs):
+            return SimpleNamespace(content=content, usage=None)
+
+        native.llm_call = reply
+
+    agent = LLMPlanner(model="offline-test")
+    agent.hooks.register(HookPoint.BEFORE_TASK, prepare)
+    agent._executor.hooks.register(HookPoint.BEFORE_TASK, prepare)
+    return agent
+
+
+class DeserializeProbeAgent:
+    async def run_session(self, session):
+        from corral.agents.schema import AgentOutcome
+        from corral.core.action import Action
+
+        class Delegate:
+            def __reduce__(self):
+                return eval, (
+                    "__import__('pathlib').Path('/opt/corral/pyproject.toml').read_text()",
+                )
+
+            async def run_session(self, child_session):
+                raise AssertionError("deserialization should have been denied")
+
+        with pytest.raises(RuntimeError, match="Permission denied"):
+            await session.run_delegate(Delegate())
+        await session.execute(
+            Action(name="submit_answer", arguments={"answer": "denied"})
+        )
+        return AgentOutcome(status="completed", answer="denied")
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize(
+    "agent_type",
+    [
+        ProbeAgent,
+        DelegatingProbeAgent,
+        native_agent_with_hooks,
+        planner_agent_with_hooks,
+        DeserializeProbeAgent,
+    ],
+)
+async def test_agent_and_subagent_execution(workspace, tmp_path, agent_type):
+    from datetime import datetime, timezone
+
+    from corral.core.task import TaskDefinition
+    from corral.observability import NoOpObserver
+    from corral.persistence import SQLiteCommitStore
+    from corral.runtime.task_runner import TaskRuntime
+
+    task = TaskDefinition(
+        name="probe",
+        description="permission probe",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        submission_format={},
+        resolve_answer=False,
+    )
+    environment = Environment(
+        "probe", task, base_work_dir=workspace, task_execution_id="probe"
+    )
+    store = SQLiteCommitStore(tmp_path / "state.sqlite3", execution_id="probe")
+    try:
+        state = await TaskRuntime(store, NoOpObserver()).run(
+            agent_type(),
+            environment,
+            execution_id="probe",
+            max_iterations=3,
+            started_at=datetime.now(timezone.utc),
+        )
+        assert state.submission is not None, state.runtime.model_dump()
+    finally:
+        await store.aclose()
+
+
+@tool
+def sdk_permission_probe(sdk: str) -> str:
+    """Start actual SDK runtimes without making a model request."""
+    import asyncio
+    import json
+    import os
+    from pathlib import Path
+
+    workspace = os.getcwd()
+    uid = os.getuid()
+
+    def assert_identity(pid):
+        status = Path(f"/proc/{pid}/status").read_text()
+        assert int(status.split("Uid:", 1)[1].split()[0]) == uid
+
+    command = ["/bin/sh", "-c", "id -u; cat /opt/corral/pyproject.toml"]
+    if sdk == "codex":
+        from openai_codex import Codex, CodexConfig
+
+        home = Path(workspace) / "codex-home"
+        home.mkdir()
+        with Codex(CodexConfig(cwd=workspace, env={"CODEX_HOME": str(home)})) as client:
+            assert_identity(client._client._proc.pid)
+            result = client._client._request_raw(
+                "command/exec",
+                {
+                    "command": command,
+                    "cwd": workspace,
+                    "sandboxPolicy": {
+                        "type": "externalSandbox",
+                        "networkAccess": "enabled",
+                    },
+                    "timeoutMs": 10000,
+                },
+            )
+            assert "Permission denied" in result["stderr"], result
+            assert str(uid) in result["stdout"], result
+    elif sdk == "claude":
+        from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+        async def check():
+            async with ClaudeSDKClient(
+                ClaudeAgentOptions(cwd=workspace, setting_sources=[])
+            ) as client:
+                assert await client.get_server_info()
+                assert_identity(client._transport._process.pid)
+
+        asyncio.run(check())
+    elif sdk == "openhands":
+        from openhands.tools.terminal import TerminalAction, TerminalExecutor
+
+        executor = TerminalExecutor(working_dir=workspace)
+        try:
+            result = executor(
+                TerminalAction(command="id -u; cat /opt/corral/pyproject.toml")
+            )
+            rendered = result.model_dump_json()
+            assert "Permission denied" in rendered, rendered
+            assert str(uid) in rendered, rendered
+        finally:
+            executor.close()
+    return json.dumps({"sdk": sdk, "uid": uid})
+
+
+@pytest.mark.skipif(
+    os.environ.get("CORRAL_PERMISSION_SDK_TESTS") != "1",
+    reason="requires all pinned SDK extras",
+)
+@pytest.mark.parametrize("sdk", ["codex", "claude", "openhands"])
+def test_real_sdk_runtime(workspace, sdk):
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    permissions.execute_tool(environment, None, sdk_permission_probe, {"sdk": sdk})
+
+
+def test_snapshot_rejects_a_symlink_swap(workspace, tmp_path, monkeypatch):
+    import errno
+    from pathlib import Path
+
+    source = Path(workspace)
+    entry = source / "data.txt"
+    entry.write_text("safe")
+    target = tmp_path / "snapshot"
+    target.mkdir()
+    original_open = os.open
+
+    def swap(path, *args, **kwargs):
+        if path == "data.txt":
+            entry.unlink()
+            entry.symlink_to("/opt/corral/pyproject.toml")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", swap)
+    with pytest.raises(OSError) as exc:
+        permissions.copy_workspace(source, target)
+    assert exc.value.errno == errno.ELOOP
+    assert not (target / "data.txt").exists()
+
+
+@tool
+def detached_process() -> str:
+    """Leave a detached descendant to check worker cleanup."""
+    import subprocess
+    import sys
+
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(300)"], start_new_session=True
+    )
+    return str(child.pid)
+
+
+def test_detached_descendant_is_stopped(workspace):
+    from pathlib import Path
+
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    pid = permissions.execute_tool(environment, None, detached_process, {})
+    try:
+        status = Path(f"/proc/{pid}/status").read_text()
+    except FileNotFoundError:
+        return
+    assert status.split("State:", 1)[1].split()[0] == "Z"
+
+
+@tool
+def forbidden_read() -> str:
+    """Read protected task code and let the permission error reach the caller."""
+    from pathlib import Path
+
+    return Path("/opt/corral/pyproject.toml").read_text()
+
+
+def test_denial_message_reaches_the_tool_caller(workspace):
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    with pytest.raises(RuntimeError, match="Permission denied:.*not permitted"):
+        permissions.execute_tool(environment, None, forbidden_read, {})
+
+
+def test_sdk_scratch_is_not_a_task_artifact(workspace, tmp_path):
+    from pathlib import Path
+
+    source = Path(workspace)
+    scratch = source / f"{permissions.SCRATCH_PREFIX}sdk"
+    scratch.mkdir()
+    (scratch / "sdk-executable").symlink_to("/bin/sh")
+    (source / "answer.txt").write_text("answer")
+    destination = tmp_path / "snapshot"
+    destination.mkdir()
+    assert permissions.copy_workspace(source, destination) == ["answer.txt"]
+    assert not (destination / scratch.name).exists()
+
+
+@tool
+def sibling_probe(path: str) -> str:
+    """Try to read another assigned workspace."""
+    from pathlib import Path
+
+    return Path(path).read_text()
+
+
+def test_workers_cannot_read_a_different_workspace(workspace):
+    import tempfile
+    from pathlib import Path
+
+    other = Path(tempfile.mkdtemp(prefix="other-workspace-", dir="/workspace"))
+    (other / "answer.txt").write_text("hidden")
+    permissions.workspace_identity(other)
+    environment = object.__new__(Environment)
+    environment.workspace_path = workspace
+    with pytest.raises(RuntimeError, match="Permission denied|No such file"):
+        permissions.execute_tool(
+            environment, None, sibling_probe, {"path": str(other / "answer.txt")}
+        )
+
+
+def test_worker_rejects_replaced_workspace_before_mount(workspace, monkeypatch):
+    from pathlib import Path
+
+    original_popen = permissions.subprocess.Popen
+    root = Path(workspace)
+    original = root.with_name(root.name + "-original")
+
+    def replace_before_bootstrap(*args, **kwargs):
+        root.rename(original)
+        root.mkdir()
+        return original_popen(*args, **kwargs)
+
+    monkeypatch.setattr(permissions.subprocess, "Popen", replace_before_bootstrap)
+    with pytest.raises(RuntimeError, match="workspace was replaced"):
+        permissions.run_worker("tool", (permission_probe, {}), workspace)
+    assert not (root / "allowed.txt").exists()
+    assert not (original / "allowed.txt").exists()
+
+
+@tool(background_capable=True)
+def node_boundary_probe(parent_file: str, sibling_file: str) -> str:
+    """Verify native and subprocess access is limited to this node's directory."""
+    import json
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    assert os.getuid() != 0
+    Path("own.txt").unlink(missing_ok=True)
+    Path("own.txt").write_text("node data")
+    for target in (
+        parent_file,
+        sibling_file,
+        "/opt/corral/pyproject.toml",
+        "/corral-state/commits.sqlite3",
+    ):
+        with pytest.raises((PermissionError, FileNotFoundError)):
+            Path(target).read_bytes()
+        with pytest.raises(OSError):
+            Path(target).write_text("forbidden")
+    link = Path(os.environ["TMPDIR"]) / "sibling-link"
+    link.symlink_to(sibling_file)
+    try:
+        with pytest.raises((PermissionError, FileNotFoundError)):
+            link.read_bytes()
+    finally:
+        link.unlink()
+    child = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from pathlib import Path; import sys; Path(sys.argv[1]).read_bytes()",
+            sibling_file,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert child.returncode != 0
+    assert Path("own.txt").read_text() == "node data"
+    Path("own.txt").chmod(0o600)
+    Path("results").mkdir(mode=0o700, exist_ok=True)
+    Path("results/plot.png").write_text("plot data")
+    return json.dumps({"confined": True})
+
+
+class IsolatedWorkspaceScientist(AIScientistAgent):
+    """Exercise actual node workers, cloning, main access, and artifact promotion."""
+
+    def _execute_session(self, session, owner, portal):
+        import traceback
+
+        from corral.agents.schema import AgentUsage
+
+        try:
+            return self._check_session(session, owner, portal)
+        except Exception:
+            # Preserve diagnostics across the harness's ExceptionGroup handling.
+            return traceback.format_exc(), AgentUsage(), {}
+
+    def _check_session(self, session, owner, portal):
+        import json
+        from pathlib import Path
+
+        from corral.agents.ai_scientist.agent import _BranchSessionRegistry
+        from corral.agents.ai_scientist.search.nodes import (
+            ExperimentNode,
+            PlannedAction,
+        )
+        from corral.agents.ai_scientist.search.tree import ExperimentTree
+        from corral.agents.ai_scientist.tools.execution_pool import ExecutionPool
+        from corral.agents.schema import AgentUsage
+        from corral.core.action import Action
+
+        assert os.getuid() != 0
+        with pytest.raises(PermissionError):
+            Path("/opt/corral/pyproject.toml").read_text()
+        Path(session.workspace, "parent.txt").write_text("parent contents")
+        sessions = _BranchSessionRegistry(session, portal)
+        pool = ExecutionPool(
+            sessions=sessions, tools=list(session.tools), max_tool_calls=30
+        )
+        try:
+            first, second = pool.create(), pool.create()
+
+            def invoke(branch, name, arguments):
+                result = branch.executor.execute_plan(
+                    [
+                        PlannedAction(
+                            purpose="Check node confinement",
+                            tool_name=name,
+                            arguments=arguments,
+                            expected_information="Only assigned node files are accessible",
+                        )
+                    ]
+                )[0]
+                assert result.success, result
+                return result.result
+
+            assert (
+                invoke(first, "read_file", {"path": "parent.txt"}) == "parent contents"
+            )
+            invoke(
+                first, "write_file", {"path": "model.txt", "content": "winning model"}
+            )
+            invoke(
+                second, "write_file", {"path": "model.txt", "content": "losing model"}
+            )
+            arguments = {
+                "parent_file": str(Path(session.workspace, "parent.txt")),
+                "sibling_file": str(Path(second.workspace, "model.txt")),
+            }
+            assert json.loads(invoke(first, "node_boundary_probe", arguments))[
+                "confined"
+            ]
+            assert Path(first.workspace, "own.txt").read_text() == "node data"
+            assert Path(first.workspace, "results/plot.png").read_text() == "plot data"
+            job = json.loads(invoke(first, "start_node_boundary_probe", arguments))
+            finished = json.loads(
+                invoke(first, "get_job_result", {"job_id": job["job_id"], "wait": True})
+            )
+            assert finished["status"] == "succeeded", finished
+            assert json.loads(finished["result"])["confined"]
+            shell = json.loads(
+                invoke(
+                    first,
+                    "terminal",
+                    {
+                        "command": "cat ../parent.txt; printf shell > shell.txt",
+                        "timeout_seconds": 30,
+                        "max_output_chars": 2000,
+                    },
+                )
+            )
+            assert (
+                "No such file" in shell["output"]
+                or "Permission denied" in shell["output"]
+            )
+            assert Path(first.workspace, "shell.txt").read_text() == "shell"
+
+            main_workspace = session.workspace
+
+            class NodeAgent:
+                async def run_session(self, child_session):
+                    from corral.agents.schema import AgentOutcome
+
+                    assert (
+                        Path(child_session.workspace, "model.txt").read_text()
+                        == "winning model"
+                    )
+                    with pytest.raises((PermissionError, FileNotFoundError)):
+                        Path(main_workspace, "parent.txt").read_text()
+                    with pytest.raises(RuntimeError, match="calling agent"):
+                        await child_session.fork_branch(workspace_parent=main_workspace)
+                    nested = await child_session.fork_branch()
+                    assert Path(nested.workspace).is_relative_to(
+                        child_session.workspace
+                    )
+                    return AgentOutcome(
+                        status="iteration_limit", error="node agent verified"
+                    )
+
+            outcome = portal.call(
+                sessions.session(first.execution_id).run_delegate, NodeAgent()
+            )
+            assert outcome.error == "node agent verified", outcome
+
+            clone = sessions.clone_branch(first.execution_id)
+            try:
+                assert len({branch.workspace for branch in (first, second, clone)}) == 3
+                for branch in (first, second, clone):
+                    assert Path(branch.workspace).parent == Path(
+                        session.workspace, ".corral-nodes"
+                    )
+                    if branch is not first:
+                        assert not Path(branch.workspace, ".corral-nodes").exists()
+                    Path(branch.workspace, "from-main.txt").write_text("main can write")
+                assert Path(clone.workspace, "model.txt").read_text() == "winning model"
+                response = clone.execute(
+                    Action(
+                        name="write_file",
+                        arguments={"path": "model.txt", "content": "changed clone"},
+                    )
+                )
+                assert response.success, response
+                assert Path(first.workspace, "model.txt").read_text() == "winning model"
+            finally:
+                sessions.close_branch(clone.execution_id)
+
+            node = ExperimentNode(
+                id="node_1",
+                branch_id=first.branch_id,
+                stage="research",
+                node_type="research",
+                hypothesis="independent artifacts",
+                rationale="probe",
+            )
+            assert not Path(session.workspace, "model.txt").exists()
+            Path(session.workspace, "model.txt").write_text("stale main output")
+            promotion = pool.promote_artifacts(
+                [node],
+                ExperimentTree(),
+                destination_workspace=session.workspace,
+                destination_execution_id=session.execution_id,
+            )
+            assert promotion.source_workspace == first.workspace
+            assert promotion.destination_workspace == session.workspace
+            assert "model.txt" in promotion.files
+            assert Path(session.workspace, "model.txt").read_text() == "winning model"
+            assert (
+                Path(session.workspace, "results/plot.png").read_text() == "plot data"
+            )
+            assert Path(second.workspace, "model.txt").read_text() == "losing model"
+            pool.close(first.branch_id)
+            assert invoke(second, "read_file", {"path": "model.txt"}) == "losing model"
+        finally:
+            assert pool.close_all() == []
+        return "node isolation verified", AgentUsage(), {}
+
+
+@pytest.mark.anyio()
+async def test_scientist_node_workspaces_in_docker(workspace, tmp_path):
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from corral.core.environment import Toolset, default_file_tools
+    from corral.core.task import TaskDefinition
+    from corral.observability import NoOpObserver
+    from corral.persistence import SQLiteCommitStore
+    from corral.runtime.task_runner import TaskRuntime
+    from corral.workspace import WorkspaceFilesystem, build_terminal_tool
+
+    task = TaskDefinition(
+        name="isolated-science",
+        description="Isolate node artifacts",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        submission_format={},
+        resolve_answer=False,
+    )
+    environment = Environment(
+        "isolated-science",
+        task,
+        base_work_dir=workspace,
+        task_execution_id="isolated",
+        toolset=Toolset(
+            pool={"node_boundary_probe": node_boundary_probe},
+            select_all_when_unspecified=True,
+            workspace_factory=lambda path: {
+                **default_file_tools(path),
+                "terminal": build_terminal_tool(WorkspaceFilesystem(path)),
+            },
+        ),
+    )
+    async with SQLiteCommitStore(
+        tmp_path / "isolated.sqlite3", execution_id="isolated"
+    ) as store:
+        try:
+            state = await TaskRuntime(store, NoOpObserver()).run(
+                IsolatedWorkspaceScientist(model="offline-test"),
+                environment,
+                execution_id="isolated",
+                max_iterations=20,
+                started_at=datetime.now(timezone.utc),
+            )
+            assert state.submission == "node isolation verified", (
+                state.submission or state.runtime.model_dump_json()
+            )
+            assert "model.txt" in state.workspace.files
+            assert not any(
+                name.startswith(".corral-nodes/") for name in state.workspace.files
+            )
+            assert (
+                Path(environment.workspace_path, "model.txt").read_text()
+                == "winning model"
+            )
+        finally:
+            environment.shutdown_jobs()
+
+
+@pytest.mark.anyio()
+async def test_internal_entrypoint_protects_a_real_trial(tmp_path):
+    from corral.orchestration.internal import run_task_from_files
+    from corral.orchestration.models import (
+        DockerSandboxSpec,
+        RunTaskInput,
+        SandboxMode,
+        SandboxProfile,
+    )
+
+    request = RunTaskInput(
+        execution_id="permission-trial",
+        task_id="probe",
+        environment_id="probe",
+        agent_id="probe",
+        started_at="2026-01-01T00:00:00+00:00",
+        sandbox=SandboxProfile(
+            mode=SandboxMode.DOCKER,
+            docker=DockerSandboxSpec(
+                image="permission-test",
+                registry_module=f"{__name__}:permission_registry",
+            ),
+        ),
+    )
+    request_path = tmp_path / "request.json"
+    import json
+    from dataclasses import asdict
+
+    request_path.write_text(json.dumps(asdict(request)))
+    result_path = tmp_path / "result.json"
+    assert await run_task_from_files(request_path, result_path) == 0
+    assert json.loads(result_path.read_text())["submission"]
+
+
+def permission_registry(request):
+    """A model-free trial using the same private registry loader as production."""
+    from corral.core.task import TaskDefinition
+    from corral.orchestration.registry import RuntimeRegistry
+
+    task = TaskDefinition(
+        name="probe",
+        description="probe",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        submission_format={},
+        resolve_answer=False,
+    )
+    return RuntimeRegistry(
+        agents={"probe": ProbeAgent()},
+        environments={"probe": Environment("probe", task, base_work_dir="/workspace")},
+    )
+
+
+def test_wetlab_stateful_tool_retains_its_environment_update(workspace):
+    engine_module = pytest.importorskip("wetlab.engine")
+    from wetlab.env import QualitativeAnalysisEnvironment
+    from wetlab.tools import mix_two_solutions
+
+    from corral.core.state import EnvironmentState, ExecutionState
+    from corral.core.transition import ToolExecutionResult
+
+    engine = engine_module.WetlabEngine(
+        engine_module.ChemicalSystemSpec(elements="K S(+6)")
+    )
+    inventory = {
+        "acid": engine.stock_solution({"H+": 0.1, "HSO4-": 0.1}, description="acid"),
+        "base": engine.stock_solution({"K+": 0.1, "OH-": 0.1}, description="base"),
+    }
+    initial = engine.snapshot(inventory).to_dict()
+    state = ExecutionState(
+        through_commit_hash="a" * 64,
+        execution_id="wetlab-permission",
+        branch_id="main",
+        environment=EnvironmentState(values={"hidden_arguments": {"wetlab": initial}}),
+    )
+    environment = object.__new__(QualitativeAnalysisEnvironment)
+    environment.workspace_path = workspace
+    result = permissions.execute_tool(
+        environment,
+        state,
+        mix_two_solutions,
+        {
+            "wetlab": initial,
+            "sol1_label": "acid",
+            "sol2_label": "base",
+            "sol1_vol": 5,
+            "sol2_vol": 5,
+            "test_label": "mixture",
+        },
+    )
+    assert isinstance(result, ToolExecutionResult)
+    assert result.environment["hidden_arguments"]["wetlab"] != initial
+
+
+class WaitingAgent:
+    async def run_session(self, session):
+        import asyncio
+        import json
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        child = subprocess.Popen(  # noqa: ASYNC220 - exercise synchronous SDK spawning
+            [sys.executable, "-c", "import time; time.sleep(300)"],
+            start_new_session=True,
+        )
+        Path(session.workspace, "started.json").write_text(
+            json.dumps([os.getpid(), child.pid])
+        )
+        await asyncio.sleep(300)
+
+
+@tool(hidden_args=["secret"], trusted=True, background_capable=True)
+def trusted_private_probe(secret: str) -> str:
+    """Use a private task input and publish only the controller identity."""
+    assert secret
+    return str(os.getuid())
+
+
+@tool(background_capable=True)
+def public_python_probe(code: str) -> str:
+    """Execute model-controlled Python in a worker with no private objects."""
+    namespace = {}
+    exec(code, namespace)
+    return "public code completed"
+
+
+class PrivateProbeEnvironment(Environment):
+    def execute_tool(self, state, selected_tool, arguments):
+        from corral.core.transition import ToolExecutionResult
+
+        if selected_tool.name != "trusted_private_probe":
+            return super().execute_tool(state, selected_tool, arguments)
+        assert selected_tool.trusted
+        assert os.getuid() == 0
+        assert (
+            arguments["secret"]
+            == state.environment.values["hidden_arguments"]["secret"]  # noqa: PD011 - EnvironmentState mapping, not pandas
+        )
+        return ToolExecutionResult(
+            content=selected_tool.execute(**arguments),
+            environment={
+                **state.environment.values,  # noqa: PD011 - EnvironmentState mapping, not pandas
+                "private_update": arguments["secret"],
+            },
+        )
+
+
+_MEMORY_PROBE = """
+import gc
+import os
+from corral.agents.session import AgentSession
+from corral.core.environment import Environment
+from corral.core.state import ExecutionState
+assert os.getuid() != 0
+assert not any(isinstance(obj, (AgentSession, ExecutionState, Environment)) for obj in gc.get_objects())
+"""
+
+
+class StateBoundaryProbe:
+    session_capabilities = AgentSessionCapabilities(inspect_subagents=True)
+
+    def __init__(self, transport):
+        self.tool_transport = transport
+
+    async def run_session(self, session):
+        import traceback
+
+        try:
+            return await self.check_boundary(session)
+        except Exception as exc:
+            raise AssertionError(traceback.format_exc()) from exc
+
+    async def check_boundary(self, session):
+        import json
+
+        from corral.agents.schema import AgentOutcome
+        from corral.core.action import Action
+        from corral.core.tool import ToolResponse
+
+        exec(_MEMORY_PROBE, {})
+        assert not hasattr(session, "state")
+        assert not hasattr(session, "previous_state")
+        assert session.get_agent_state("hidden_arguments") is None
+        await session.set_agent_state("public-notes", {"note": "remember this"})
+        assert session.get_agent_state("public-notes") == {"note": "remember this"}
+        with pytest.raises(RuntimeError, match="not permitted"):
+            session._sync_call("state", {})
+
+        async def invoke(name, arguments):
+            if self.tool_transport == "python":
+                return await session.execute(Action(name=name, arguments=arguments))
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+
+            async with (
+                streamablehttp_client(session.tool_connection.mcp_url) as streams,
+                ClientSession(streams[0], streams[1]) as client,
+            ):
+                await client.initialize()
+                result = await client.call_tool(name, arguments)
+                content = "".join(
+                    item.text for item in result.content if item.type == "text"
+                )
+                return ToolResponse(
+                    success=not result.isError, result=content, error=None
+                )
+
+        response = await invoke("trusted_private_probe", {})
+        assert response.success, response
+        assert response.result == "0", response
+        rejected = await invoke("trusted_private_probe", {"secret": "forged"})
+        assert not rejected.success
+        response = await invoke("public_python_probe", {"code": _MEMORY_PROBE})
+        assert response.success, response
+        response = await invoke(
+            "terminal",
+            {
+                "command": "id -u; cat /opt/corral/pyproject.toml",
+                "timeout_seconds": 120,
+                "max_output_chars": 20000,
+            },
+        )
+        assert response.success, response
+        assert "Permission denied" in response.result
+        for name, arguments in (
+            ("public_python_probe", {"code": _MEMORY_PROBE}),
+            ("trusted_private_probe", {}),
+        ):
+            started = await invoke("start_" + name, arguments)
+            assert started.success, started
+            job_id = json.loads(started.result)["job_id"]
+            finished = await invoke("get_job_result", {"job_id": job_id, "wait": True})
+            assert finished.success, finished
+            assert json.loads(finished.result)["result"] in {
+                "0",
+                "public code completed",
+            }
+
+        class Child:
+            async def run_session(self, child_session):
+                exec(_MEMORY_PROBE, {})
+                response = await child_session.execute(
+                    Action(name="trusted_private_probe", arguments={})
+                )
+                assert response.success, response
+                assert response.result == "0", response
+                return AgentOutcome(status="completed", answer="public child result")
+
+        child_id = await session.spawn_subagent(Child(), handoff="Public child task")
+        assert (
+            await session.wait_for_subagent(child_id)
+        ).answer == "public child result"
+        trace = await session.inspect_subagent(child_id)
+        assert trace.commits == ()
+        assert trace.context.task.metadata == {}
+        trace_tool = await invoke(
+            "inspect_subagent", {"child_run_id": child_id, "include_commits": True}
+        )
+        assert json.loads(trace_tool.result)["commits"] == []
+        imported = await session.import_subagent_context(child_id)
+        assert isinstance(imported, str)
+        assert len(imported) == 64
+        branch = await session.fork_branch()
+        assert not hasattr(branch, "state")
+        assert branch.get_agent_state("hidden_arguments") is None
+        await session.execute(
+            Action(name="submit_answer", arguments={"answer": "boundary held"})
+        )
+        return AgentOutcome(status="completed", answer="boundary held")
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("transport", ["python", "mcp"])
+async def test_private_state_stays_in_controller(
+    workspace, tmp_path, monkeypatch, transport
+):
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    from corral.core.environment import Toolset
+    from corral.core.task import EnvironmentSetup, TaskDefinition
+    from corral.observability import NoOpObserver
+    from corral.persistence import SQLiteCommitStore
+    from corral.runtime.task_runner import TaskRuntime
+    from corral.workspace import WorkspaceFilesystem, build_terminal_tool
+
+    secret = str(uuid4())
+    requests = []
+    original_worker = permissions.run_worker
+
+    def audited_worker(kind, payload, workspace, **kwargs):
+        serialized = permissions.serialize(payload)
+        assert secret.encode() not in serialized
+        requests.append(kind)
+        return original_worker(kind, payload, workspace, **kwargs)
+
+    monkeypatch.setattr(permissions, "run_worker", audited_worker)
+    task = TaskDefinition(
+        name="private-probe",
+        description="Public task instructions",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        scoring_inputs={"answer": secret},
+        submission_format={},
+        resolve_answer=False,
+        setup_fn=lambda env, state: EnvironmentSetup(
+            hidden_arguments={"secret": secret}
+        ),
+    )
+    environment = PrivateProbeEnvironment(
+        "private-probe",
+        task,
+        base_work_dir=workspace,
+        task_execution_id="boundary",
+        toolset=Toolset(
+            select_all_when_unspecified=True,
+            pool={
+                tool.name: tool for tool in (trusted_private_probe, public_python_probe)
+            },
+            workspace_factory=lambda path: {
+                "terminal": build_terminal_tool(WorkspaceFilesystem(path))
+            },
+        ),
+    )
+    store = SQLiteCommitStore(tmp_path / "boundary.sqlite3", execution_id="boundary")
+    try:
+        state = await TaskRuntime(store, NoOpObserver()).run(
+            StateBoundaryProbe(transport),
+            environment,
+            execution_id="boundary",
+            max_iterations=20,
+            started_at=datetime.now(timezone.utc),
+        )
+        assert state.submission == "boundary held", state.runtime.model_dump_json()
+        assert state.environment.values["hidden_arguments"]["secret"] == secret  # noqa: PD011 - EnvironmentState mapping, not pandas
+        assert state.environment.values["private_update"] == secret  # noqa: PD011 - EnvironmentState mapping, not pandas
+        assert secret not in state.model_dump_json(include={"conversations"})
+        assert {"agent", "tool", "terminal"} <= set(requests)
+    finally:
+        environment.shutdown_jobs()
+        await store.aclose()
+
+
+@pytest.mark.anyio()
+async def test_cancelled_agent_stops_its_descendants_before_returning(
+    workspace, tmp_path
+):
+    import asyncio
+    import json
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    from corral.core.task import TaskDefinition
+    from corral.observability import NoOpObserver
+    from corral.persistence import SQLiteCommitStore
+    from corral.runtime.task_runner import TaskRuntime
+
+    task = TaskDefinition(
+        name="cancel",
+        description="probe",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        submission_format={},
+        resolve_answer=False,
+    )
+    environment = Environment(
+        "cancel", task, base_work_dir=workspace, task_execution_id="cancel"
+    )
+    store = SQLiteCommitStore(tmp_path / "cancel.sqlite3", execution_id="cancel")
+    running = asyncio.create_task(
+        TaskRuntime(store, NoOpObserver()).run(
+            WaitingAgent(),
+            environment,
+            execution_id="cancel",
+            max_iterations=3,
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    started = Path(environment.workspace_path) / "started.json"
+    try:
+        async with asyncio.timeout(20):
+            while not started.exists():
+                if running.done():
+                    raise AssertionError(
+                        f"worker stopped before cancellation: {running.result()}"
+                    )
+                await asyncio.sleep(0.05)
+            pids = json.loads(started.read_text())
+            running.cancel()
+            await asyncio.gather(running, return_exceptions=True)
+        for pid in pids:
+            try:
+                status = Path(f"/proc/{pid}/status").read_text()
+            except FileNotFoundError:
+                continue
+            assert status.split("State:", 1)[1].split()[0] == "Z"
+    finally:
+        running.cancel()
+        await asyncio.gather(running, return_exceptions=True)
+        await store.aclose()

--- a/tests/runtime/test_worker_boundary.py
+++ b/tests/runtime/test_worker_boundary.py
@@ -1,0 +1,244 @@
+"""Portable checks for the data allowed to cross the worker boundary."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import cloudpickle
+import pytest
+from tests.agents.commit_session import start_session
+
+from corral.agents.llm_planner import LLMPlanner
+from corral.core.environment import Environment, Toolset
+from corral.core.state import EnvironmentState, ExecutionState
+from corral.core.task import EnvironmentSetup, TaskDefinition
+from corral.core.tool import tool
+from corral.core.transition import ToolExecutionResult
+from corral.runtime import permissions
+from corral.runtime.agent_worker import RemoteSession, _snapshot
+from corral.workspace import WorkspaceFilesystem, build_terminal_tool
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio()
+async def test_planner_delegates_without_reopening_packaged_prompts(monkeypatch):
+    planner = LLMPlanner(model="offline-test")
+    payload = permissions.serialize(planner)
+    prompt_store = Mock(side_effect=PermissionError("packaged prompts are private"))
+    monkeypatch.setattr("corral.agents.base_agent.PromptStore", prompt_store)
+    planner = cloudpickle.loads(payload)
+    model_call = AsyncMock(
+        side_effect=[
+            SimpleNamespace(
+                content="Use the executor to submit the answer.",
+                usage={"prompt_tokens": 2, "completion_tokens": 1},
+            ),
+            SimpleNamespace(
+                content=(
+                    "<action>submit_answer</action>"
+                    '<action_input>{"answer":"42"}</action_input>'
+                ),
+                usage={"prompt_tokens": 3, "completion_tokens": 2},
+            ),
+        ]
+    )
+    monkeypatch.setattr("corral.agents.base_agent.llm_call", model_call)
+    task = TaskDefinition(
+        name="planner-task",
+        description="Compute the answer",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        submission_format={},
+        resolve_answer=False,
+    )
+    session = await start_session(
+        Environment(
+            "planner-task", task, toolset=Toolset(pool={}, workspace_factory=None)
+        ),
+        max_iterations=2,
+    )
+    try:
+        result = await planner.run_session(session)
+        assert result.status == "completed"
+        assert result.answer == session.submission == "42"
+        assert result.metadata["executor"] == "ReActAgent"
+        assert result.usage.llm_calls == model_call.await_count == 2
+        assert result.usage.input_tokens == 5
+        assert result.usage.output_tokens == 3
+        prompt_store.assert_not_called()
+    finally:
+        await session._test_commit_store.aclose()
+
+
+@pytest.mark.anyio()
+async def test_agent_snapshot_contains_no_private_projection():
+    secret = str(uuid4())
+    task = TaskDefinition(
+        name="public-task",
+        description="Public instructions",
+        tools=[],
+        scoring_fn=lambda answer: 1.0,
+        scoring_inputs={"answer": secret},
+        submission_format={},
+        setup_fn=lambda env, state: EnvironmentSetup(
+            hidden_arguments={"answer": secret}
+        ),
+    )
+    session = await start_session(
+        Environment(
+            "public-task", task, toolset=Toolset(pool={}, workspace_factory=None)
+        )
+    )
+    try:
+        await session.record_message({"role": "user", "content": "public history"})
+        session.previous_state = session.state
+        session._last_score = {"score": 0.25, "trial_id": "attempt", "private": secret}
+        snapshot = _snapshot(session)
+        assert secret not in json.dumps(snapshot)
+        assert (
+            not {"state", "previous_state", "context", "runtime_actor"}
+            & snapshot.keys()
+        )
+        assert snapshot["previous_evaluation"] == {"score": 0.25, "trial_id": "attempt"}
+        assert snapshot["previous_messages"][-1]["content"] == "public history"
+        remote = RemoteSession("localhost", 0, "token", "handle", snapshot)
+        assert not hasattr(remote, "state")
+        assert not hasattr(remote, "previous_state")
+    finally:
+        await session._test_commit_store.aclose()
+
+
+@pytest.fixture()
+def private_state():
+    return ExecutionState(
+        execution_id="private",
+        branch_id="main",
+        through_commit_hash="a" * 64,
+        environment=EnvironmentState(
+            values={"hidden_arguments": {"answer": str(uuid4())}}
+        ),
+    )
+
+
+def test_serialization_rejects_private_objects_in_agent_closures(private_state):
+    class CapturingAgent:
+        async def run_session(self, session):
+            return private_state.submission
+
+    with pytest.raises(ValueError, match="private controller object"):
+        permissions.serialize(CapturingAgent())
+    with pytest.raises(ValueError, match="private controller object"):
+        permissions.serialize({"nested": [private_state]})
+
+
+def test_shell_payload_is_only_command_options(tmp_path, private_state, monkeypatch):
+    terminal = build_terminal_tool(WorkspaceFilesystem(tmp_path))
+    terminal.accidentally_captured_state = private_state
+    environment = SimpleNamespace(workspace_path=str(tmp_path), private=private_state)
+    requests = []
+
+    def run(kind, payload, workspace, **kwargs):
+        requests.append((kind, payload, workspace))
+        return {"content": "public output"}
+
+    monkeypatch.setattr(permissions, "run_worker", run)
+    assert (
+        permissions.execute_tool(
+            environment, private_state, terminal, {"command": "pwd"}
+        )
+        == "public output"
+    )
+    assert requests == [("terminal", {"command": "pwd"}, str(tmp_path))]
+
+
+@tool(hidden_args=["secret"])
+def private_code_tool(code: str, secret: str) -> str:
+    """An unsafe tool that must never receive hidden inputs in Docker."""
+    return code + secret
+
+
+@pytest.mark.parametrize("background", [False, True])
+def test_untrusted_tools_with_private_inputs_fail_closed(
+    tmp_path, monkeypatch, background
+):
+    monkeypatch.setattr(
+        permissions,
+        "run_worker",
+        lambda *args, **kwargs: pytest.fail("worker must not start"),
+    )
+    arguments = {"code": "print('public')", "secret": str(uuid4())}
+    with pytest.raises(PermissionError, match="cannot receive hidden arguments"):
+        if background:
+            permissions.execute_job(private_code_tool, arguments, str(tmp_path))
+        else:
+            permissions.execute_tool(
+                SimpleNamespace(workspace_path=str(tmp_path)),
+                None,
+                private_code_tool,
+                arguments,
+            )
+
+
+@tool(hidden_args=["work_dir"], workspace_args=("work_dir",))
+def workspace_tool(work_dir: str) -> str:
+    """Return the public workspace binding."""
+    return work_dir
+
+
+def test_workspace_binding_is_rebuilt_without_private_inputs(tmp_path, monkeypatch):
+    secret = str(uuid4())
+
+    def run(kind, payload, workspace, **kwargs):
+        assert secret.encode() not in permissions.serialize(payload)
+        assert payload[1] == {"work_dir": str(tmp_path)}
+        return {"content": str(tmp_path)}
+
+    monkeypatch.setattr(permissions, "run_worker", run)
+    assert permissions.execute_job(
+        workspace_tool, {"work_dir": secret}, str(tmp_path)
+    ) == str(tmp_path)
+
+
+def test_public_schema_rejects_injected_hidden_arguments():
+    assert (
+        permissions.visible_argument_error(private_code_tool, {"code": "public"})
+        is None
+    )
+    assert "secret" in permissions.visible_argument_error(
+        private_code_tool, {"code": "public", "secret": "override"}
+    )
+
+
+def test_background_result_cannot_publish_private_state(tmp_path):
+    @tool(trusted=True)
+    def private_result() -> ToolExecutionResult:
+        """Return a private transition, which is valid only in the foreground."""
+        return ToolExecutionResult(
+            content="public", environment={"private": str(uuid4())}
+        )
+
+    with pytest.raises(ValueError, match="must execute in the foreground"):
+        permissions.execute_job(private_result, {}, str(tmp_path))
+
+
+def test_node_creation_and_copy_reject_symlink_ancestors(tmp_path):
+    parent = tmp_path / "trial"
+    parent.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("private data")
+    nodes = parent / permissions.NODE_WORKSPACE_DIR
+    nodes.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(OSError):
+        permissions.create_node_workspace(str(parent), str(parent))
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    with pytest.raises(OSError):
+        permissions.copy_workspace(nodes / "nested", destination)
+    assert not list(destination.iterdir())
+    assert (outside / "secret.txt").read_text() == "private data"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,14 @@ class SubmitAgent:
         return AgentOutcome(status="completed", answer="42")
 
 
+class FailingAgent:
+    model = "test-model"
+    error = "BadRequestError: unsupported reasoning_effort 'none'"
+
+    async def run_session(self, session):
+        return AgentOutcome(status="agent_failure", error=self.error)
+
+
 def _unexpected_score(_answer):
     raise AssertionError("corral run must not invoke the task scorer")
 
@@ -120,15 +128,16 @@ def test_create_agent_accepts_class_and_separator_aliases():
     assert cli.normalise_agent_name("AI_Scientist") == "ai-scientist"
 
 
-def test_tool_calling_uses_cli_safe_reasoning_default_and_allows_override():
+@pytest.mark.parametrize("reasoning_effort", ["low", "none"])
+def test_tool_calling_omits_reasoning_default_and_allows_override(reasoning_effort):
     default_agent = cli.create_agent("tool-calling")
     overridden_agent = cli.create_agent(
         "tool-calling",
-        agent_kwargs={"reasoning_effort": "low"},
+        agent_kwargs={"reasoning_effort": reasoning_effort},
     )
 
-    assert default_agent.kwargs["reasoning_effort"] == "none"
-    assert overridden_agent.kwargs["reasoning_effort"] == "low"
+    assert "reasoning_effort" not in default_agent.kwargs
+    assert overridden_agent.kwargs["reasoning_effort"] == reasoning_effort
 
 
 def test_reflexion_builds_a_configurable_actor():
@@ -324,13 +333,16 @@ def test_run_rejects_task_dependencies(monkeypatch):
         asyncio.run(cli.run_task(args))
 
 
-def test_run_executes_one_task_without_a_benchmark(monkeypatch, tmp_path, capsys):
+@pytest.mark.parametrize("agent_class", [SubmitAgent, FailingAgent])
+def test_run_executes_one_task_without_a_benchmark(
+    monkeypatch, tmp_path, capsys, agent_class
+):
     monkeypatch.setattr(
         cli,
         "load_environment_group",
         lambda *args, **kwargs: {"task1": _environment("task1")},
     )
-    monkeypatch.setattr(cli, "create_agent", lambda *args, **kwargs: SubmitAgent())
+    monkeypatch.setattr(cli, "create_agent", lambda *args, **kwargs: agent_class())
     args = cli.build_parser().parse_args(
         [
             "run",
@@ -349,12 +361,18 @@ def test_run_executes_one_task_without_a_benchmark(monkeypatch, tmp_path, capsys
 
     result = asyncio.run(cli.run_task(args))
 
-    assert result == 0
+    failed = agent_class is FailingAgent
+    assert result == int(failed)
     output = capsys.readouterr().out
     assert "Run cli-direct-task completed:" in output
     assert "- task: task1" in output
-    assert "- status: submitted" in output
-    assert '- answer: "42"' in output
+    if failed:
+        assert "- status: failed" in output
+        assert f"- error: {FailingAgent.error}" in output
+    else:
+        assert "- status: submitted" in output
+        assert '- answer: "42"' in output
+        assert "- error:" not in output
 
 
 def test_unknown_agent_error_lists_available_agents():
@@ -404,13 +422,16 @@ def test_legacy_script_retains_existing_defaults():
     assert args.trials == 1
 
 
-def test_benchmark_runs_locally_and_writes_report(monkeypatch, tmp_path):
+@pytest.mark.parametrize("agent_class", [SubmitAgent, FailingAgent])
+def test_benchmark_runs_locally_and_writes_report(
+    monkeypatch, tmp_path, capsys, agent_class
+):
     monkeypatch.setattr(
         cli,
         "load_environment_group",
         lambda *args, **kwargs: {"task1": _environment("task1")},
     )
-    monkeypatch.setattr(cli, "create_agent", lambda *args, **kwargs: SubmitAgent())
+    monkeypatch.setattr(cli, "create_agent", lambda *args, **kwargs: agent_class())
     args = cli.build_parser().parse_args(
         [
             "bench",
@@ -429,11 +450,17 @@ def test_benchmark_runs_locally_and_writes_report(monkeypatch, tmp_path):
             str(tmp_path),
         ]
     )
-    assert asyncio.run(cli.run_benchmark(args)) == 0
+    failed = agent_class is FailingAgent
+    assert asyncio.run(cli.run_benchmark(args)) == int(failed)
+    output = capsys.readouterr().out
+    if failed:
+        assert output.count(f"  error: {FailingAgent.error}") == args.trials
+    else:
+        assert "  error:" not in output
     reports = list(tmp_path.rglob("report.json"))
     assert len(reports) == 1
     report = json.loads(reports[0].read_text())
     assert report["metadata"]["benchmark"]["trials_per_task"] == 2
     manifest = json.loads((reports[0].parent / "run-metadata.json").read_text())
-    assert manifest["status"] == "completed"
+    assert manifest["status"] == ("completed_with_errors" if failed else "completed")
     assert len(list(reports[0].parent.rglob("commits.sqlite3"))) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1469,7 +1469,6 @@ dependencies = [
     { name = "litellm", version = "1.84.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "loguru" },
     { name = "mcp" },
-    { name = "modal" },
     { name = "more-itertools" },
     { name = "netcdf4", version = "1.7.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and platform_machine == 'ARM64' and sys_platform == 'win32'" },
     { name = "netcdf4", version = "1.7.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or platform_machine != 'ARM64' or sys_platform != 'win32'" },
@@ -1545,6 +1544,7 @@ langfuse = [
 openhands = [
     { name = "openhands-sdk", marker = "python_full_version >= '3.12'" },
     { name = "openhands-tools", marker = "python_full_version >= '3.12'" },
+    { name = "playwright", marker = "python_full_version >= '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -1594,7 +1594,6 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
     { name = "mkdocs-terminal", marker = "extra == 'docs'", specifier = ">=4.7.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.22.0" },
-    { name = "modal", specifier = ">=1.1.4" },
     { name = "more-itertools", specifier = ">=10.7.0" },
     { name = "netcdf4", specifier = ">=1.7.3" },
     { name = "numpy" },
@@ -1606,6 +1605,7 @@ requires-dist = [
     { name = "openhands-tools", marker = "python_full_version >= '3.12' and extra == 'openhands'", specifier = "==1.35.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'docs'", specifier = ">=10.0.0" },
+    { name = "playwright", marker = "python_full_version >= '3.12' and extra == 'openhands'", specifier = ">=1.49.0,<2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "promptstore", git = "https://github.com/lamalab-org/promptstore.git?rev=main" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=14.0.0" },
@@ -2739,38 +2739,12 @@ wheels = [
 ]
 
 [[package]]
-name = "grpclib"
-version = "0.4.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h2" },
-    { name = "multidict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/0f0d3524b38b35e5cd07334b754aa9bd0570140ad982131b04ebfa3b0374/grpclib-0.4.8.tar.gz", hash = "sha256:d8823763780ef94fed8b2c562f7485cf0bbee15fc7d065a640673667f7719c9a", size = 62793, upload-time = "2025-05-04T16:27:30.051Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/8b/ad381ec1b8195fa4a9a693cb8087e031b99530c0d6b8ad036dcb99e144c4/grpclib-0.4.8-py3-none-any.whl", hash = "sha256:a5047733a7acc1c1cee6abf3c841c7c6fab67d2844a45a853b113fa2e6cd2654", size = 76311, upload-time = "2025-05-04T16:27:22.818Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -2844,15 +2818,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
     { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
     { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -2975,15 +2940,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -4603,31 +4559,6 @@ wheels = [
 ]
 
 [[package]]
-name = "modal"
-version = "1.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp", version = "3.12.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "aiohttp", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "certifi" },
-    { name = "click" },
-    { name = "grpclib" },
-    { name = "protobuf" },
-    { name = "rich" },
-    { name = "synchronicity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "types-certifi" },
-    { name = "types-toml" },
-    { name = "typing-extensions" },
-    { name = "watchfiles" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/96/6696e536e7d0063eab645c11330e2daa5b87dbccc12c719307079b362050/modal-1.1.4.tar.gz", hash = "sha256:67f612f41ef6091e24a92fb9bb158fabf5e8f6ff7351a2c7ae2140bb112b871b", size = 594653, upload-time = "2025-09-03T22:25:38.44Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/cf/6b3988de454d65e6f5b6471400dbb1f28ad4784f24abd5d3f392a39df782/modal-1.1.4-py3-none-any.whl", hash = "sha256:fcacbc22c5db59b76239f54e16e35c5a4a24cda10b465f1e4750311418939212", size = 685859, upload-time = "2025-09-03T22:25:35.477Z" },
-]
-
-[[package]]
 name = "more-itertools"
 version = "10.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6203,6 +6134,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "python_full_version >= '3.12'" },
+    { name = "pyee", marker = "python_full_version >= '3.12'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6812,6 +6762,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -11021,18 +10983,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sigtools"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/db/669ca14166814da187b3087b908ca924cf83f5b504fe23b3859a3ef67d4f/sigtools-4.0.1.tar.gz", hash = "sha256:4b8e135a9cd4d2ea00da670c093372d74e672ba3abb87f4c98d8e73dea54445c", size = 71910, upload-time = "2022-10-13T07:03:54.149Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/91/853dbf6ec096197dba9cd5fd0c836c5fc19142038b7db60ebe6332b1bab1/sigtools-4.0.1-py2.py3-none-any.whl", hash = "sha256:d216b4cf920bbab0fce636ddc429ed8463a5b533d9e1492acb45a2a1bc36ac6c", size = 76419, upload-time = "2022-10-13T07:03:52.658Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -11438,19 +11388,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "synchronicity"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sigtools" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/b6/e977f03915cc02406bb52ac15398ea44dbde47805e5955b6bac9268acc12/synchronicity-0.10.2.tar.gz", hash = "sha256:e0dfd8a2ba4fb89c60ee53365c5fa2d2d69aabce60709055d38f736f6a592c86", size = 53891, upload-time = "2025-07-30T20:23:19.122Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/f9/ce041b9531022a0b5999a47e6da14485239f7bce9c595d1bfb387fe60e89/synchronicity-0.10.2-py3-none-any.whl", hash = "sha256:4ba1f8c02ca582ef068033300201e3c403e08d81e42553554f4e67b27f0d9bb1", size = 38766, upload-time = "2025-07-30T20:23:18.04Z" },
 ]
 
 [[package]]
@@ -11903,15 +11840,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-certifi"
-version = "2021.10.8.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
-]
-
-[[package]]
 name = "types-requests"
 version = "2.33.0.20260518"
 source = { registry = "https://pypi.org/simple" }
@@ -11921,15 +11849,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
-]
-
-[[package]]
-name = "types-toml"
-version = "0.10.8.20240310"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/47/3e4c75042792bff8e90d7991aa5c51812cc668828cc6cce711e97f63a607/types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331", size = 4392, upload-time = "2024-03-10T02:18:37.518Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/a2/d32ab58c0b216912638b140ab2170ee4b8644067c293b170e19fba340ccc/types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d", size = 4777, upload-time = "2024-03-10T02:18:36.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Solve issues #390, #391, and #392
- Simplify the `llm_call` function so that no arguments are set unexpectedly
- The issue #392 stripped the failing isolation in the Docker container: the agent could look in the files in `/opt` for the codebase. Therefore, I tried to solve this by banning the agents' access to all the directories inside the Docker container except in `/workspace`. The permissions right now are managed by Unix permissions. This required defining a worker for the agents and ensuring that the spawned subprocesses of the agents also do not have those permissions.

## Summary by Sourcery

Harden Docker execution around workspace-only access while correcting agent branching, LLM configuration, SDK timeouts, and failure reporting.

New Features:
- Enforce workspace-root isolation for Docker agents, tools, subprocesses, and background jobs through restricted worker identities and filesystem boundaries.
- Provide isolated per-node workspaces for AI Scientist branches with explicit artifact promotion to the owning trial workspace.
- Apply configurable OpenHands MCP timeouts across both transport and executor layers, including native-tool collision handling.
- Add Playwright support to the OpenHands dependency extra and prepare Docker images for the permission policy.

Bug Fixes:
- Stop agents from accessing private code, checkpoints, task state, and sibling workspaces inside Docker containers.
- Preserve caller-supplied LLM configuration without injecting model-, temperature-, token-, or tool-selection arguments.
- Preserve workspace roots and private runtime directories during Modal synchronization.
- Expose agent and trial failure messages in CLI output and benchmark results.

Enhancements:
- Broker restricted agent session operations through a narrow JSON interface while keeping private controller state out of worker processes.
- Refine session projections and agent APIs to expose only public model, conversation, evaluation, and submission data.
- Classify tools as trusted or workspace-bound and fail closed when untrusted tools request private inputs.
- Update the Docker runtime protocol and launch configuration to require the new permission policy.

Build:
- Prepare benchmark and wetlab Docker images with required packages and protected image permissions.

Deployment:
- Strengthen Docker isolation using a root bootstrap, dropped worker privileges, private mount namespaces, and workspace-only mounts.

Tests:
- Add coverage for Docker permission boundaries, worker descendants, isolated node workspaces, artifact promotion, OpenHands timeout enforcement, LLM argument preservation, CLI failures, and safe Modal synchronization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission-controlled execution for agents, tools, background jobs, and Docker workers.
  * Added isolated workspaces for branched executions, with support for promoting branch artifacts.
  * Added configurable OpenHands MCP and tool execution timeouts.
  * Added workspace-aware tool metadata and trusted-tool execution.
  * Added clearer reporting of task and trial failures.

* **Bug Fixes**
  * Improved workspace path protection, snapshot safety, and preservation during remote updates.
  * Prevented private runtime files and sensitive state from crossing execution boundaries.
  * Standardized forwarding of language-model request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->